### PR TITLE
Rename function transforEnvs for clarity

### DIFF
--- a/relayer-engine/src/config/index.ts
+++ b/relayer-engine/src/config/index.ts
@@ -84,7 +84,7 @@ export function getListenerEnv(): ListenerEnv {
   return listenerEnv;
 }
 
-export function transforEnvs({
+export function transformEnvs({
   mode,
   rawCommonEnv,
   rawListenerEnv,
@@ -114,7 +114,7 @@ export function validateEnvs(input: {
 }) {
   console.log("Validating envs...");
   try {
-    input = transforEnvs(input);
+    input = transformEnvs(input);
   } catch (e) {
   }
   commonEnv = validateCommonEnv(input.rawCommonEnv);


### PR DESCRIPTION
Renamed `transforEnvs` function to `transformEnvs` for clarity.