### PR TITLE
Catch errors in handleWorkflow

### DIFF
--- a/relayer-engine/src/utils/providers.ts
+++ b/relayer-engine/src/utils/providers.ts
@@ -29,7 +29,7 @@ export function providersFromChainConfig(
   )?.nodeUrl;
   if (!solanaUrl) {
     // todo: change me!!!!!!
-    solanaUrl = "http://localhost:8899"
+    solanaUrl = "http://localhost:8899";
     // todo: generalize this
     // throw new Error("Expected solana rpc url to be defined");
   }


### PR DESCRIPTION
If the plugin's handleWorkflow method throws, catch the error so that the process does not crash

Also guards against VAAs coming from spy that do not have sufficient signatures