### PR TITLE
Adds configs to redis

### DIFF
--- a/example-project/relayer-engine-config/common.json
+++ b/example-project/relayer-engine-config/common.json
@@ -3,8 +3,10 @@
   "storeType": "Redis",
   "readinessPort": 2000,
   "numGuardians": 1,
-  "redisPort": 6379,
-  "redisHost": "localhost",
+  "redis": {
+    "port": 6379,
+    "host": "localhost"
+  },
   "defaultWorkflowOptions": {
     "maxRetries": 10
   },

--- a/relayer-engine/src/config/index.ts
+++ b/relayer-engine/src/config/index.ts
@@ -52,7 +52,7 @@ export interface CommonEnv {
   readinessPort?: number;
   logDir?: string;
   storeType: StoreType;
-  redis: RedisConfig;
+  redis?: RedisConfig;
   pluginURIs?: NodeURI[];
   numGuardians?: number;
   wormholeRpc: string;

--- a/relayer-engine/src/config/index.ts
+++ b/relayer-engine/src/config/index.ts
@@ -42,7 +42,7 @@ export interface RedisConfig {
   port: number;
   username?: string;
   password?: string;
-  tls: boolean;
+  tls?: boolean;
 }
 
 export interface CommonEnv {

--- a/relayer-engine/src/config/index.ts
+++ b/relayer-engine/src/config/index.ts
@@ -37,6 +37,14 @@ export enum Mode {
 }
 export type NodeURI = string;
 
+export interface RedisConfig {
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  tls: boolean;
+}
+
 export interface CommonEnv {
   namespace?: string;
   logLevel?: string;
@@ -44,8 +52,7 @@ export interface CommonEnv {
   readinessPort?: number;
   logDir?: string;
   storeType: StoreType;
-  redisHost?: string;
-  redisPort?: number;
+  redis: RedisConfig;
   pluginURIs?: NodeURI[];
   numGuardians?: number;
   wormholeRpc: string;

--- a/relayer-engine/src/config/loadConfig.ts
+++ b/relayer-engine/src/config/loadConfig.ts
@@ -45,6 +45,9 @@ export async function loadUntypedEnvs(
 async function loadCommon(dir: string): Promise<any> {
   const obj = await loadFileAndParseToObject(`${dir}/common.json`);
   if (obj.redis) {
+    if (process.env.RELAYER_ENGINE_REDIS_HOST) {
+      obj.redis.host = process.env.RELAYER_ENGINE_REDIS_HOST;
+    }
     if (process.env.RELAYER_ENGINE_REDIS_USERNAME) {
       obj.redis.username = process.env.RELAYER_ENGINE_REDIS_USERNAME;
     }

--- a/relayer-engine/src/config/loadConfig.ts
+++ b/relayer-engine/src/config/loadConfig.ts
@@ -5,7 +5,7 @@
 import * as yaml from "js-yaml";
 import * as fs from "fs";
 import * as nodePath from "path";
-import { CommonEnv, ExecutorEnv, Mode, PrivateKeys } from ".";
+import { CommonEnv, ExecutorEnv, Mode, PrivateKeys, RedisConfig } from ".";
 import { ChainId } from "@certusone/wormhole-sdk";
 import { dbg } from "../helpers/logHelper";
 
@@ -21,7 +21,7 @@ export async function loadUntypedEnvs(
   rawListenerEnv: any;
   rawExecutorEnv: any;
 }> {
-  const rawCommonEnv = await loadCommon(dir, mode);
+  const rawCommonEnv = await loadCommon(dir);
   rawCommonEnv.mode = mode;
   console.log("Successfully loaded the common config file.");
 
@@ -42,9 +42,16 @@ export async function loadUntypedEnvs(
   };
 }
 
-async function loadCommon(dir: string, mode: Mode): Promise<any> {
+async function loadCommon(dir: string): Promise<any> {
   const obj = await loadFileAndParseToObject(`${dir}/common.json`);
-  obj.mode = mode;
+  if (obj.redis) {
+    if (process.env.RELAYER_ENGINE_REDIS_USERNAME) {
+      obj.redis.username = process.env.RELAYER_ENGINE_REDIS_USERNAME;
+    }
+    if (process.env.RELAYER_ENGINE_REDIS_PASSWORD) {
+      obj.redis.password = process.env.RELAYER_ENGINE_REDIS_PASSWORD;
+    }
+  }
   return obj;
 }
 

--- a/relayer-engine/src/config/validateConfig.ts
+++ b/relayer-engine/src/config/validateConfig.ts
@@ -11,6 +11,7 @@ import {
 import { CommonEnv, ExecutorEnv, ListenerEnv, Mode, StoreType } from ".";
 import {
   assertArray,
+  assertBool,
   assertInt,
   assertStr,
   EngineError,
@@ -27,8 +28,13 @@ export function validateCommonEnv(raw: Keys<CommonEnv>): CommonEnv {
     namespace: raw.namespace,
     logLevel: raw.logLevel,
     storeType: validateStringEnum<StoreType>(StoreType, raw.storeType),
-    redisHost: raw.redisHost,
-    redisPort: raw.redisPort && assertInt(raw.redisPort, "redisPort"),
+    redis: {
+      host: raw.redis?.host,
+      port: raw.redis?.port && assertInt(raw.redis?.port, "redis.port"),
+      username: raw.redis?.username,
+      password: raw.redis?.password,
+      tls: raw.redis?.tls && assertBool(raw.redis?.tls, "redis.bool"),
+    },
     pluginURIs: raw.pluginURIs && assertArray(raw.pluginURIs, "pluginURIs"),
     mode: validateStringEnum<Mode>(Mode, raw.mode),
     promPort: raw.promPort && assertInt(raw.promPort, "promPort"),

--- a/relayer-engine/src/config/validateConfig.ts
+++ b/relayer-engine/src/config/validateConfig.ts
@@ -33,7 +33,7 @@ export function validateCommonEnv(raw: Keys<CommonEnv>): CommonEnv {
       port: raw.redis?.port && assertInt(raw.redis?.port, "redis.port"),
       username: raw.redis?.username,
       password: raw.redis?.password,
-      tls: raw.redis?.tls && assertBool(raw.redis?.tls, "redis.bool"),
+      tls: raw.redis?.tls && assertBool(raw.redis?.tls, "redis.tls"),
     },
     pluginURIs: raw.pluginURIs && assertArray(raw.pluginURIs, "pluginURIs"),
     mode: validateStringEnum<Mode>(Mode, raw.mode),

--- a/relayer-engine/src/storage/storage.test.ts
+++ b/relayer-engine/src/storage/storage.test.ts
@@ -41,8 +41,8 @@ const TEST_ID = "test-id";
 describe("Storage tests", () => {
   beforeAll(async () => {
     store = await RedisWrapper.fromConfig({
-      redisHost: "localhost",
-      redisPort: 6301,
+      host: "localhost",
+      port: 6301,
     });
     if (!store) {
       throw new Error("Could not conect to redis");

--- a/relayer-engine/src/storage/storage.ts
+++ b/relayer-engine/src/storage/storage.ts
@@ -81,7 +81,7 @@ export class Storage {
     this.plugins = new Map(plugins.map(p => [p.pluginName, p]));
     if (!this.namespace) {
       this.logger.warn(
-        "You are starting a relayer without a namespace, which could cause issues if you run multiple relayer over the same Redis instance",
+        "You are starting a relayer without a namespace, which could cause issues if you run multiple relayers using the same Redis instance",
       );
     }
     this.constants = constantsWithNamespace(this.namespace);

--- a/relayer-engine/src/storage/storage.ts
+++ b/relayer-engine/src/storage/storage.ts
@@ -18,10 +18,10 @@ import {
 import { getLogger, getScopedLogger } from "../helpers/logHelper";
 import { EngineError, nnull } from "../utils/utils";
 import { MAX_ACTIVE_WORKFLOWS } from "../executor/executorHarness";
-import { RedisConfig, RedisWrapper } from "./redisStore";
+import { RedisWrapper } from "./redisStore";
 import { ChainId } from "@certusone/wormhole-sdk";
-import { CommonEnv } from "../config";
-import { constantsWithNamespace } from './dbConstants';
+import { CommonEnv, RedisConfig } from "../config";
+import { constantsWithNamespace } from "./dbConstants";
 
 type SerializedWorkflowKeys = { [k in keyof Workflow]: string | number };
 
@@ -31,8 +31,8 @@ export async function createStorage(
   nodeId: string,
   logger: Logger = getLogger(),
 ): Promise<Storage> {
-  const redisConfig = config as RedisConfig;
-  if (!redisConfig.redisHost || !redisConfig.redisPort) {
+  const redisConfig = config.redis as RedisConfig;
+  if (!redisConfig.host || !redisConfig.port) {
     throw new EngineError(
       "Redis config values must be present if redis store type selected",
     );
@@ -43,7 +43,7 @@ export async function createStorage(
     config.defaultWorkflowOptions,
     nodeId,
     logger,
-    config.namespace
+    config.namespace,
   );
 }
 
@@ -75,12 +75,14 @@ export class Storage {
     private readonly _defaultWorkflowOptions: WorkflowOptions,
     private readonly nodeId: string,
     logger: Logger,
-    private readonly namespace: string = ""
+    private readonly namespace: string = "",
   ) {
     this.logger = getScopedLogger([`GlobalStorage`], logger);
     this.plugins = new Map(plugins.map(p => [p.pluginName, p]));
     if (!this.namespace) {
-      this.logger.warn('You are starting a relayer without a namespace, which could cause issues if you run multiple relayer over the same Redis instance');
+      this.logger.warn(
+        "You are starting a relayer without a namespace, which could cause issues if you run multiple relayer over the same Redis instance",
+      );
     }
     this.constants = constantsWithNamespace(this.namespace);
   }
@@ -138,7 +140,11 @@ export class Storage {
 
         // only set the record if we are able to aquire the lock
         if (await this.acquireUnsafeLock(redis, key, 50)) {
-          await redis.hSet(this.constants.EMITTER_KEY, key, JSON.stringify(record));
+          await redis.hSet(
+            this.constants.EMITTER_KEY,
+            key,
+            JSON.stringify(record),
+          );
           await this.releaseUnsafeLock(redis, key);
           this.logger.debug(
             `Updated emitter record. Key ${key}, ${JSON.stringify(record)}`,
@@ -185,15 +191,21 @@ export class Storage {
 
   // Number of active workflows currently being executed
   numActiveWorkflows(): Promise<number> {
-    return this.store.withRedis(redis => redis.lLen(this.constants.ACTIVE_WORKFLOWS_QUEUE));
+    return this.store.withRedis(redis =>
+      redis.lLen(this.constants.ACTIVE_WORKFLOWS_QUEUE),
+    );
   }
 
   numEnqueuedWorkflows(): Promise<number> {
-    return this.store.withRedis(redis => redis.lLen(this.constants.READY_WORKFLOW_QUEUE));
+    return this.store.withRedis(redis =>
+      redis.lLen(this.constants.READY_WORKFLOW_QUEUE),
+    );
   }
 
   numDelayedWorkflows(): Promise<number> {
-    return this.store.withRedis(redis => redis.lLen(this.constants.DELAYED_WORKFLOWS_QUEUE));
+    return this.store.withRedis(redis =>
+      redis.lLen(this.constants.DELAYED_WORKFLOWS_QUEUE),
+    );
   }
 
   private serializeWorkflow(workflow: Workflow): Record<string, any> {
@@ -372,7 +384,12 @@ export class Storage {
   }
 
   getStagingAreaKeyLock(pluginName: string): StagingAreaKeyLock {
-    return new DefaultStagingAreaKeyLock(this.store, this.constants, this.logger, pluginName);
+    return new DefaultStagingAreaKeyLock(
+      this.store,
+      this.constants,
+      this.logger,
+      pluginName,
+    );
   }
 
   // this is a simple lock which under the wrong conditions cannot guarantee exclusivity
@@ -508,7 +525,9 @@ export class Storage {
         }
 
         const aMinuteAgo = new Date(Date.now() - 60000);
-        const executors = await redis.hGetAll(this.constants.EXECUTORS_HEARTBEAT_HASH);
+        const executors = await redis.hGetAll(
+          this.constants.EXECUTORS_HEARTBEAT_HASH,
+        );
         const deadExecutors: Record<string, boolean> = {};
         for (const executorId of Object.keys(executors)) {
           const lastHeartbeat = new Date(executors[executorId]);
@@ -575,7 +594,9 @@ export class Storage {
   }
 
   private _workflowKey(workflow: { id: string; pluginName: string }): string {
-    return this.namespace ? `${this.namespace}/${workflow.pluginName}/${workflow.id}` : `${workflow.pluginName}/${workflow.id}`
+    return this.namespace
+      ? `${this.namespace}/${workflow.pluginName}/${workflow.id}`
+      : `${workflow.pluginName}/${workflow.id}`;
   }
 }
 
@@ -587,7 +608,9 @@ class DefaultStagingAreaKeyLock implements StagingAreaKeyLock {
     readonly logger: Logger,
     pluginName: string,
   ) {
-    this.stagingAreaKey = `${this.constants.STAGING_AREA_KEY}/${sanitize(pluginName)}`;
+    this.stagingAreaKey = `${this.constants.STAGING_AREA_KEY}/${sanitize(
+      pluginName,
+    )}`;
   }
 
   getKeys<KV extends Record<string, any>>(keys: string[]): Promise<KV> {


### PR DESCRIPTION
In k8s we need to auth into redis and it's using TLS so we need to be able to pass in those env vars. Refactored redis config fields into a nested object and reading password from environment.