### PR TITLE
Fix: allow nested calls to `withKeys` by passing tx object

### DIFF
--- a/relayer-engine/packages/relayer-plugin-interface/lib/index.d.ts
+++ b/relayer-engine/packages/relayer-plugin-interface/lib/index.d.ts
@@ -38,24 +38,24 @@ export interface ActionExecutor {
     onSolana<T>(f: ActionFunc<T, SolanaWallet>): Promise<T>;
     onEVM<T>(action: Action<T, EVMWallet>): Promise<T>;
 }
-export declare type ActionFunc<T, W extends Wallet> = (walletToolBox: WalletToolBox<W>, chaidId: ChainId) => Promise<T>;
+export type ActionFunc<T, W extends Wallet> = (walletToolBox: WalletToolBox<W>, chaidId: ChainId) => Promise<T>;
 export interface Action<T, W extends Wallet> {
     chainId: ChainId;
     f: ActionFunc<T, W>;
 }
-export declare type WorkflowId = string;
-export declare type UntypedProvider = {
+export type WorkflowId = string;
+export type UntypedProvider = {
     rpcUrl: string;
 };
-export declare type EVMWallet = ethers.Wallet;
-export declare type UntypedWallet = UntypedProvider & {
+export type EVMWallet = ethers.Wallet;
+export type UntypedWallet = UntypedProvider & {
     privateKey: string;
 };
-export declare type SolanaWallet = {
+export type SolanaWallet = {
     conn: solana.Connection;
     payer: solana.Keypair;
 };
-export declare type Wallet = EVMWallet | SolanaWallet | UntypedWallet;
+export type Wallet = EVMWallet | SolanaWallet | UntypedWallet;
 export interface WalletToolBox<T extends Wallet> extends Providers {
     wallet: T;
 }
@@ -74,7 +74,7 @@ export interface PluginDefinition<PluginConfig, PluginType extends Plugin<Workfl
     };
     pluginName: string;
 }
-export declare type EngineInitFn<PluginType extends Plugin> = (engineConfig: CommonPluginEnv, logger: winston.Logger) => PluginType;
+export type EngineInitFn<PluginType extends Plugin> = (engineConfig: CommonPluginEnv, logger: winston.Logger) => PluginType;
 export interface WorkflowOptions {
     maxRetries?: number;
 }
@@ -96,15 +96,16 @@ export interface Plugin<WorkflowData = any> {
     } | undefined>;
     handleWorkflow(workflow: Workflow<WorkflowData>, providers: Providers, execute: ActionExecutor): Promise<void>;
 }
-export declare type EventSource = (event: SignedVaa, extraData?: any[]) => Promise<void>;
-export declare type ContractFilter = {
+export type EventSource = (event: SignedVaa, extraData?: any[]) => Promise<void>;
+export type ContractFilter = {
     emitterAddress: string;
     chainId: ChainId;
 };
 export interface StagingAreaKeyLock {
-    withKey<T, KV extends Record<string, any>>(keys: string[], f: (kv: KV) => Promise<{
+    withKey<T, KV extends Record<string, any>>(keys: string[], f: (kvs: KV, ctx: OpaqueTx) => Promise<{
         newKV: KV;
         val: T;
-    }>): Promise<T>;
+    }>, tx?: OpaqueTx): Promise<T>;
     getKeys<KV extends Record<string, any>>(keys: string[]): Promise<KV>;
 }
+export type OpaqueTx = never;

--- a/relayer-engine/packages/relayer-plugin-interface/src/index.ts
+++ b/relayer-engine/packages/relayer-plugin-interface/src/index.ts
@@ -146,10 +146,13 @@ export interface Plugin<WorkflowData = any> {
     stagingArea: StagingAreaKeyLock,
     providers: Providers,
     extraData?: any[],
-  ): Promise<{
-    workflowData: WorkflowData;
-    workflowOptions?: WorkflowOptions;
-  } | undefined>;
+  ): Promise<
+    | {
+        workflowData: WorkflowData;
+        workflowOptions?: WorkflowOptions;
+      }
+    | undefined
+  >;
   handleWorkflow(
     workflow: Workflow<WorkflowData>,
     providers: Providers,
@@ -170,7 +173,10 @@ export type ContractFilter = {
 export interface StagingAreaKeyLock {
   withKey<T, KV extends Record<string, any>>(
     keys: string[],
-    f: (kv: KV) => Promise<{ newKV: KV; val: T }>,
+    f: (kvs: KV, ctx: OpaqueTx) => Promise<{ newKV: KV; val: T }>,
+    tx?: OpaqueTx,
   ): Promise<T>;
   getKeys<KV extends Record<string, any>>(keys: string[]): Promise<KV>;
 }
+
+export type OpaqueTx = never;

--- a/relayer-engine/src/storage/redisStore.ts
+++ b/relayer-engine/src/storage/redisStore.ts
@@ -69,6 +69,7 @@ async function createConnection(
           password,
           isolationPoolOptions: {
             min: 2,
+            max: 10,
           },
         },
       });
@@ -90,6 +91,7 @@ async function createConnection(
         password,
         isolationPoolOptions: {
           min: 2,
+          max: 10,
         },
       });
       await client.connect();


### PR DESCRIPTION
Discussion from slack

> Joe Howarth
:mountain:  [16 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675901659985439)
[@gzimmermann](https://teamillini.slack.com/team/U04LXGVQF1R)
 / 
[@sscatularo](https://teamillini.slack.com/team/U04LLLJ4ENB)
 could I get a review on this relayer engine pr? This is exposing some more paper cuts with transactionality and redis
 https://github.com/wormhole-foundation/relayer-engine/pull/64


>Gabriel Zimmermann
:man-running:  [16 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675901834249149?thread_ts=1675901659.985439&cid=C04G11W5927)
Just my ignorance but OpaqueTx is never; what does that mean? Hehe not familiar with the idiom


>Sebastián Nale
  [15 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675904993109669?thread_ts=1675901659.985439&cid=C04G11W5927)
I think that conceptually, you can think of it as a type that represents a sort of empty set for types; that probably misses subtleties in the type system but, roughly, if you take a type e.g. number and take the type number out of it you're left with the type never
If I remember correctly, no instance should typecheck as never.


>Sebastián Nale
  [15 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675905243277239?thread_ts=1675901659.985439&cid=C04G11W5927)
https://www.typescriptlang.org/play?#code/FAMwrgdgxgLglgewgAhgUwM4wBQA8BcyEYAtgEZoBOAlMgN7DJPJwjLYwCeADmgm7mQBCALwjkAImLkqE2g2aLkAemXJBACypoWGVDx0ADCGgBuVQ4yVNcAbitMAvsGfAuvZABVk4gKK4oABswABM0AB5pCkoAGiJSaIA+e1BIWEQUdCwAJjxCT3kHFTVNbV19D2MzCxdgIA
typescriptlang.orgtypescriptlang.org
[TS Playground - An online editor for exploring TypeScript and JavaScript](https://www.typescriptlang.org/play#code/FAMwrgdgxgLglgewgAhgUwM4wBQA8BcyEYAtgEZoBOAlMgN7DJPJwjLYwCeADmgm7mQBCALwjkAImLkqE2g2aLkAemXJBACypoWGVDx0ADCGgBuVQ4yVNcAbitMAvsGfAuvZABVk4gKK4oABswABM0AB5pCkoAGiJSaIA+e1BIWEQUdCwAJjxCT3kHFTVNbV19D2MzCxdgIA)
The Playground lets you write TypeScript or JavaScript online in a safe and sharable way.


>Sebastián Nale
  [15 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675905767627469?thread_ts=1675901659.985439&cid=C04G11W5927)
If I remember correctly, no instance should typecheck as never.
What I mean by this, is that no value can be assigned to a variable of type never. Nor passed as an argument to a function that expects that type, etc


>Joe Howarth
:mountain:  [15 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675906225870659?thread_ts=1675901659.985439&cid=C04G11W5927)
yeah that's the idea


>Joe Howarth
:mountain:  [15 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675906257501799?thread_ts=1675901659.985439&cid=C04G11W5927)
basically I wanted to create an opaque type that nobody could accidentally pass in a value that would fit
:+1:
1



>Juan Sebastian Scatularo
  [14 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675907876288069?thread_ts=1675901659.985439&cid=C04G11W5927)
I am not sure if I understand your Idea 
[@jhowarth](https://teamillini.slack.com/team/U02PQNE7811)
, withKey method, takes a key set, and a mutation function, then it gets the redis key set lock, mutate it, and releases the lock, and now the mutation function requires a ctx that is an OpaqueTx, that is never, so it is not allowed to be provided, right?, do you have an example use case?


>Joe Howarth
:mountain:  [14 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675907978756279?thread_ts=1675901659.985439&cid=C04G11W5927)
yeah [https://github.com/wormhole-foundation/trustless-generic-relayer/pull/85/files#diff-85d8d2293dc74e875eae0db86293[…]4216509c621b37657cf9462fR142-R207](https://github.com/wormhole-foundation/trustless-generic-relayer/pull/85/files#diff-85d8d2293dc74e875eae0db862933cea5fb7bbfa4216509c621b37657cf9462fR142-R207)


>Joe Howarth
:mountain:  [14 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675908023580709?thread_ts=1675901659.985439&cid=C04G11W5927)
here we have a nested withKeys invocation where the output of the first is used as keys of the second


>Joe Howarth
:mountain:  [14 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675908082974389?thread_ts=1675901659.985439&cid=C04G11W5927)
I'm not happy with the api, but I didn't think of something better


>Juan Sebastian Scatularo
  [14 hours ago](https://teamillini.slack.com/archives/C04G11W5927/p1675910068998089?thread_ts=1675901659.985439&cid=C04G11W5927)
I see, I think I have a better understanding, my wondering now, if why you need to pass back the redis reference, it should not change on a single-threaded environment like node, right?, so, before continuing with the outer function mutation, execution environment will wait first for the call back of this method https://github.com/wormhole-foundation/trustless-generic-relayer/pull/85/files#diff-85d8d2293dc74e875eae0db862933cea5fb7bbfa4216509c621b37657cf9462fR170, or is there something that I'm missing, I am asking just for my own education


>Joe Howarth
:mountain:  [3 minutes ago](https://teamillini.slack.com/archives/C04G11W5927/p1675959656178399?thread_ts=1675901659.985439&cid=C04G11W5927)
Yeah the issue is not really about mutating the redis client, it's that we run the redis client using executeIsolated which gives exclusive access to one client. ([code](https://github.com/wormhole-foundation/relayer-engine/blob/d66fd90408e6728a00596f6dbfe3485ab59ead07/relayer-engine/src/storage/redisStore.ts#L28))
Empircally I've found that we deadlock frequently whenever we call executeIsolated from within another executeIsolated operation. To avoid this we give the option of passing the client that was used by the outer tx. This shouldn't be an issue anymore because now we're allowing [more clients to be created](https://github.com/wormhole-foundation/relayer-engine/pull/64/files#diff-ce181c5f9a900b31fb534ab8c3b41280293d03e4cacb53f4ef28a16fca4b7299R72), but there is also an issue where watch invocations aren't carried over unless the same client is used, so we would like to give caller the option of reusing the client.
I don't have a deep understanding of redis or the redis js client though, so I may be missing something
New

>Juan Sebastian Scatularo
  [2 minutes ago](https://teamillini.slack.com/archives/C04G11W5927/p1675959772610109?thread_ts=1675901659.985439&cid=C04G11W5927)
I see, thank you 
[@jhowarth](https://teamillini.slack.com/team/U02PQNE7811)
, for explaining it :slightly_smiling_face: