### PR TITLE
Adds catching where it was missing and stores failed information for workflow in redis

### DIFF
--- a/relayer-engine/packages/relayer-plugin-interface/lib/index.d.ts
+++ b/relayer-engine/packages/relayer-plugin-interface/lib/index.d.ts
@@ -29,6 +29,8 @@ export interface Workflow<D = any> {
     maxRetries?: number;
     data: D;
     failedAt?: Date;
+    errorMessage?: string;
+    errorStacktrace?: string;
     completedAt?: Date;
     startedProcessingAt?: Date;
     processingBy?: string;

--- a/relayer-engine/packages/relayer-plugin-interface/lib/index.d.ts
+++ b/relayer-engine/packages/relayer-plugin-interface/lib/index.d.ts
@@ -38,24 +38,24 @@ export interface ActionExecutor {
     onSolana<T>(f: ActionFunc<T, SolanaWallet>): Promise<T>;
     onEVM<T>(action: Action<T, EVMWallet>): Promise<T>;
 }
-export declare type ActionFunc<T, W extends Wallet> = (walletToolBox: WalletToolBox<W>, chaidId: ChainId) => Promise<T>;
+export type ActionFunc<T, W extends Wallet> = (walletToolBox: WalletToolBox<W>, chaidId: ChainId) => Promise<T>;
 export interface Action<T, W extends Wallet> {
     chainId: ChainId;
     f: ActionFunc<T, W>;
 }
-export declare type WorkflowId = string;
-export declare type UntypedProvider = {
+export type WorkflowId = string;
+export type UntypedProvider = {
     rpcUrl: string;
 };
-export declare type EVMWallet = ethers.Wallet;
-export declare type UntypedWallet = UntypedProvider & {
+export type EVMWallet = ethers.Wallet;
+export type UntypedWallet = UntypedProvider & {
     privateKey: string;
 };
-export declare type SolanaWallet = {
+export type SolanaWallet = {
     conn: solana.Connection;
     payer: solana.Keypair;
 };
-export declare type Wallet = EVMWallet | SolanaWallet | UntypedWallet;
+export type Wallet = EVMWallet | SolanaWallet | UntypedWallet;
 export interface WalletToolBox<T extends Wallet> extends Providers {
     wallet: T;
 }
@@ -74,7 +74,7 @@ export interface PluginDefinition<PluginConfig, PluginType extends Plugin<Workfl
     };
     pluginName: string;
 }
-export declare type EngineInitFn<PluginType extends Plugin> = (engineConfig: CommonPluginEnv, logger: winston.Logger) => PluginType;
+export type EngineInitFn<PluginType extends Plugin> = (engineConfig: CommonPluginEnv, logger: winston.Logger) => PluginType;
 export interface WorkflowOptions {
     maxRetries?: number;
 }
@@ -96,15 +96,16 @@ export interface Plugin<WorkflowData = any> {
     } | undefined>;
     handleWorkflow(workflow: Workflow<WorkflowData>, providers: Providers, execute: ActionExecutor): Promise<void>;
 }
-export declare type EventSource = (event: SignedVaa, extraData?: any[]) => Promise<void>;
-export declare type ContractFilter = {
+export type EventSource = (event: SignedVaa, extraData?: any[]) => Promise<void>;
+export type ContractFilter = {
     emitterAddress: string;
     chainId: ChainId;
 };
 export interface StagingAreaKeyLock {
-    withKey<T, KV extends Record<string, any>>(keys: string[], f: (kv: KV) => Promise<{
+    withKey<T, KV extends Record<string, any>>(keys: string[], f: (kvs: KV, ctx: OpaqueTx) => Promise<{
         newKV: KV;
         val: T;
-    }>): Promise<T>;
+    }>, tx?: OpaqueTx): Promise<T>;
     getKeys<KV extends Record<string, any>>(keys: string[]): Promise<KV>;
 }
+export type OpaqueTx = never;

--- a/relayer-engine/packages/relayer-plugin-interface/src/index.ts
+++ b/relayer-engine/packages/relayer-plugin-interface/src/index.ts
@@ -47,6 +47,8 @@ export interface Workflow<D = any> {
   maxRetries?: number;
   data: D;
   failedAt?: Date;
+  errorMessage?: string;
+  errorStacktrace?: string;
   completedAt?: Date;
   startedProcessingAt?: Date;
   processingBy?: string;

--- a/relayer-engine/packages/relayer-plugin-interface/src/index.ts
+++ b/relayer-engine/packages/relayer-plugin-interface/src/index.ts
@@ -146,10 +146,13 @@ export interface Plugin<WorkflowData = any> {
     stagingArea: StagingAreaKeyLock,
     providers: Providers,
     extraData?: any[],
-  ): Promise<{
-    workflowData: WorkflowData;
-    workflowOptions?: WorkflowOptions;
-  } | undefined>;
+  ): Promise<
+    | {
+        workflowData: WorkflowData;
+        workflowOptions?: WorkflowOptions;
+      }
+    | undefined
+  >;
   handleWorkflow(
     workflow: Workflow<WorkflowData>,
     providers: Providers,
@@ -170,7 +173,10 @@ export type ContractFilter = {
 export interface StagingAreaKeyLock {
   withKey<T, KV extends Record<string, any>>(
     keys: string[],
-    f: (kv: KV) => Promise<{ newKV: KV; val: T }>,
+    f: (kvs: KV, ctx: OpaqueTx) => Promise<{ newKV: KV; val: T }>,
+    tx?: OpaqueTx,
   ): Promise<T>;
   getKeys<KV extends Record<string, any>>(keys: string[]): Promise<KV>;
 }
+
+export type OpaqueTx = never;

--- a/relayer-engine/src/executor/executorHarness.ts
+++ b/relayer-engine/src/executor/executorHarness.ts
@@ -211,6 +211,10 @@ async function spawnWorkflow(
       );
       completedWorkflows.labels({ plugin: plugin.pluginName }).inc();
     } catch (e) {
+      if (e instanceof Error) {
+        workflow.errorMessage = e.message;
+        workflow.errorStacktrace = e.stack;
+      }
       logger.warn(
         `Workflow ${workflow.id} for plugin ${workflow.pluginName} errored:`,
       );

--- a/relayer-engine/src/storage/redisStore.ts
+++ b/relayer-engine/src/storage/redisStore.ts
@@ -69,6 +69,7 @@ async function createConnection(
           password,
           isolationPoolOptions: {
             min: 2,
+            max: 10,
           },
         },
       });
@@ -90,6 +91,7 @@ async function createConnection(
         password,
         isolationPoolOptions: {
           min: 2,
+          max: 10,
         },
       });
       await client.connect();

--- a/relayer-engine/src/storage/storage.ts
+++ b/relayer-engine/src/storage/storage.ts
@@ -263,6 +263,8 @@ export class Storage {
         .hSet(key, <SerializedWorkflowKeys>{
           processingBy: "",
           startedProcessingAt: "",
+          errorMessage: workflow.errorMessage,
+          errorStacktrace: workflow.errorStacktrace,
         })
         .hIncrBy(key, "retryCount", 1);
       op =
@@ -294,6 +296,8 @@ export class Storage {
           completedAt: now.toString(),
           processingBy: "",
           startedProcessingAt: "",
+          errorMessage: "",
+          errorStacktrace: "",
         })
         .lRem(this.constants.ACTIVE_WORKFLOWS_QUEUE, 0, key)
         .exec(true);
@@ -303,6 +307,8 @@ export class Storage {
   failWorkflow(workflow: {
     id: WorkflowId;
     pluginName: string;
+    errorMessage?: string;
+    errorStacktrace?: string;
   }): Promise<void> {
     const key = this._workflowKey(workflow);
     return this.store.runOpWithRetry(async redis => {
@@ -314,8 +320,10 @@ export class Storage {
       const now = new Date();
       await redis
         .multi()
-        .hSet(key, <SerializedWorkflowKeys>{
+        .hSet(key, <Partial<SerializedWorkflowKeys>>{
           failedAt: now.toString(),
+          failedMessage: workflow.errorMessage,
+          failedStacktrace: workflow.errorStacktrace,
           processingBy: "",
           startedProcessingAt: "",
         })


### PR DESCRIPTION
Accomplishes 2 this:
1. Stores error information in redis when a workflow fails. To remove later: stacktrace. Once we have structured logging in place.
2. Added a catch for when fetching missing vaas fails so it doesn't interrupt the spy workflow.