### PR TITLE
Adds completed queue with a 100 elem cap

### DIFF
--- a/relayer-engine/src/api/controller.ts
+++ b/relayer-engine/src/api/controller.ts
@@ -41,10 +41,13 @@ class WorkflowsController {
       case "reattempting":
         workflows = await this.storage.getDelayedWorkflows(0, -1);
         break;
+      case "completed":
+        workflows = await this.storage.getCompletedWorkflows(0, -1);
+        break;
       default:
         ctx.status = 400;
         ctx.body =
-          "Wrong status, allowed values are: reattempting, ready, failed, inprogress";
+          "Wrong status, allowed values are: reattempting, ready, failed, inprogress, completed";
         return;
     }
     ctx.body = workflows;

--- a/relayer-engine/src/storage/dbConstants.ts
+++ b/relayer-engine/src/storage/dbConstants.ts
@@ -1,6 +1,7 @@
 const CONSTANTS = {
   READY_WORKFLOW_QUEUE: "__workflowQ", // workflows ready to execute
   ACTIVE_WORKFLOWS_QUEUE: "__activeWorkflows",
+  COMPLETED_WORKFLOWS_QUEUE: "__completedWorkflows",
   DEAD_LETTER_QUEUE: "__deadWorkflows",
   DELAYED_WORKFLOWS_QUEUE: "__delayedWorkflows", // failed workflows being delayed before going back to ready to execute
   EXECUTORS_HEARTBEAT_HASH: "__executorsHeartbeats",
@@ -17,6 +18,9 @@ const CONSTANTS = {
  *                  the result is going to be a copy of the current constant object.
  * @returns a new object with all the namespaced constants or a copy of it if non namespace was provided
  */
-export const constantsWithNamespace = (namespace: string): Record<string, string> => Object.entries(CONSTANTS)
-    .map(([key,value]) => ({ [key]: [namespace, value].join("") }))
+export const constantsWithNamespace = (
+  namespace: string,
+): Record<string, string> =>
+  Object.entries(CONSTANTS)
+    .map(([key, value]) => ({ [key]: [namespace, value].join("") }))
     .reduce((acc, item) => ({ ...acc, ...item }), {});

--- a/relayer-engine/src/storage/index.ts
+++ b/relayer-engine/src/storage/index.ts
@@ -83,6 +83,7 @@ export interface Multi {
   del(key: string): Multi;
   exists(keys: string): Multi;
   lPush(key: string, element: string | string[]): Multi;
+  lTrim(key: string, start: number, end: number): Multi;
   zAdd(key: string, elements: { value: string; score: number }[]): Multi;
   lRem(key: string, count: number, element: string): Multi;
   zRem(key: string, element: string | string[]): Multi;

--- a/relayer-engine/src/storage/storage.test.ts
+++ b/relayer-engine/src/storage/storage.test.ts
@@ -78,6 +78,11 @@ describe("Storage tests", () => {
       emitterAddress: "abc123",
       emitterChain: 1,
       sequence: "5",
+      completedAt: undefined,
+      failedAt: undefined,
+      errorMessage: undefined,
+      errorStacktrace: undefined,
+      processingBy: "test-id",
     };
     const key = workflowKey(workflow);
 
@@ -100,6 +105,7 @@ describe("Storage tests", () => {
       const res = await storage.getNextWorkflow(1);
       expect(res).toBeTruthy();
       logger.info(res);
+      workflow.startedProcessingAt = res!.workflow.startedProcessingAt;
       expect(res!.workflow).toEqual(workflow);
       expect(await redis.lLen("__activeWorkflows")).toBe(1);
       expect(await redis.lIndex("__activeWorkflows", 0)).toBe(key);

--- a/relayer-engine/src/storage/storage.ts
+++ b/relayer-engine/src/storage/storage.ts
@@ -320,13 +320,7 @@ export class Storage {
       const rawWorkflows = await Promise.all(
         activeWorkflowsIds.map(id => redis.hGetAll(id)),
       );
-      const workflows = rawWorkflows.map(raw => this.rawObjToWorkflow(raw));
-      // sort by last workflow to first
-      workflows.sort(
-        (a, b) =>
-          (b.scheduledAt?.getTime() ?? 0) - (a.scheduledAt?.getTime() ?? 0),
-      );
-      return workflows;
+      return rawWorkflows.map(raw => this.rawObjToWorkflow(raw));
     });
   }
 
@@ -451,7 +445,6 @@ export class Storage {
           startedProcessingAt: "",
         })
         .lRem(this.constants.ACTIVE_WORKFLOWS_QUEUE, 0, key)
-        .lRem(this.constants.COMPLETED_WORKFLOWS_QUEUE, 0, key)
         .lRem(this.constants.COMPLETED_WORKFLOWS_QUEUE, 0, key)
         .zRem(this.constants.DELAYED_WORKFLOWS_QUEUE, key)
         .lPush(this.constants.DEAD_LETTER_QUEUE, key)


### PR DESCRIPTION
Sometimes it's useful to see the last completed workflows. Right now you have to scan the entire database to achieve that and inspect each workflow. It'd be nice to have them in a list however because the list can grow quite large I added a 100 element cap (in the future maybe you can make that configurable?)