### PR TITLE
Create/update issue templates on wormhole-foundation/relayer-engine repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Submit a bug ticket if you have an issue. If you're a user, check out the Wormhole Discord server below for faster assistance.
+title: ''
+labels: 'bug'
+assignees: ''
+---
+<!--- Fill out the fields if you're an integrator or contributor. -->
+
+## Description and context
+<!--- Provide a detailed description of the problem to expedite the process. -->
+
+
+## Steps to reproduce
+<!--- Describe what happened step by step. -->
+<!--- If applicable, provide a link to a live example or include code to reproduce. -->
+
+1.
+2.
+3.
+
+## Experienced behavior
+<!--- Describe what happened after the last step. -->
+
+
+## Expected behavior
+<!--- Describe what was expected to happen instead. -->
+
+
+## Solution recommendation
+<!--- Not mandatory, but feel free to recommend a way fix the issue. -->
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Wormhole Official Discord
+    url: https://discord.gg/wormholecrypto
+    about: If you're a user, this is the fastest way to get help. Do not give your wallet private key or mnemonic words to anyone.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: Create a regular work item to be picked up by a contributor.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description and context
+<!--- Write a description or todo list as the scope. A task should be: -->
+<!--- Actionable: can be acted on right away. -->
+<!--- Clearly defined scope: has precise limits/boundaries. -->
+<!--- Small scope: break complex tasks into smaller ones if they involve multiple system parts, multiple people/PRs, or parallelizable work. -->
+
+## Definition of done
+<!--- Describe completion: e.g. code merged, deployment is done, or release published etc. -->

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -1,0 +1,25 @@
+---
+name: Tracking issue
+about: Tracking issues are task lists used to better organize regular work items.
+title: 'Tracking issue for *ADD_PROJECT* - *ADD_COMPONENT*'
+labels: 'epic'
+assignees: ''
+
+---
+
+This issue is for grouping *ADD_COMPONENT* related tasks that are necessary for *ADD_PROJECT*.
+
+### Other tracking issues for the same project:
+<!--- Link related tracking issues within the project for easier navigation. -->
+<!--- Assign tasks to the appropriate tracking issue if there is more than one. -->
+
+- #XXXX
+- #XXXX
+- #XXXX
+
+<!--- Subtasks MUST be inside the ``` -> ``` code block. -->
+```[tasklist]
+### Task list
+- [ ] XXXX
+- [ ] XXXX
+```


### PR DESCRIPTION
closes #102

Update the issue templates on GitHub to standardize the way tasks are created for better readability.