### PR TITLE
Makes storage implementation swappable

### DIFF
--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -10,66 +10,16 @@
       "license": "ISC",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.9.11",
+        "@wormhole-foundation/relayer-engine": "file:../",
         "koa": "^2.14.1",
         "koa-router": "^12.0.0",
         "node-redis": "^0.1.7",
         "winston": "^3.8.2",
-        "wormhole-relayer": "file:../",
         "yargs": "^17.7.1"
       },
       "devDependencies": {
         "@types/koa-router": "^7.4.4",
         "@types/yargs": "^17.0.22",
-        "prettier": "^2.8.4"
-      }
-    },
-    "..": {
-      "version": "0.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "@bull-board/api": "^5.0.0",
-        "@bull-board/koa": "^5.0.0",
-        "@certusone/wormhole-sdk": "^0.9.11",
-        "@certusone/wormhole-spydk": "^0.0.1",
-        "@datastructures-js/queue": "^4.2.3",
-        "bech32": "^2.0.0",
-        "bullmq": "^3.10.1",
-        "ethers": "^5.7.2",
-        "generic-pool": "^3.9.0",
-        "ioredis": "^5.3.1",
-        "koa": "^2.14.1",
-        "prom-client": "^14.2.0",
-        "typescript": "^4.9.5",
-        "winston": "^3.8.2"
-      },
-      "devDependencies": {
-        "@types/koa": "^2.13.5",
-        "@types/winston": "^2.4.4",
-        "prettier": "^2.8.4"
-      }
-    },
-    "../relayer": {
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@bull-board/api": "^5.0.0",
-        "@bull-board/koa": "^5.0.0",
-        "@certusone/wormhole-sdk": "^0.9.11",
-        "@certusone/wormhole-spydk": "^0.0.1",
-        "@datastructures-js/queue": "^4.2.3",
-        "bech32": "^2.0.0",
-        "bullmq": "^3.10.1",
-        "ethers": "^5.7.2",
-        "generic-pool": "^3.9.0",
-        "ioredis": "^5.3.1",
-        "koa": "^2.14.1",
-        "prom-client": "^14.2.0",
-        "winston": "^3.8.2"
-      },
-      "devDependencies": {
-        "@types/koa": "^2.13.5",
-        "@types/winston": "^2.4.4",
         "prettier": "^2.8.4"
       }
     },
@@ -125,6 +75,52 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bull-board/api": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-5.0.0.tgz",
+      "integrity": "sha512-nOB8TUSeX8h2wgMxmPZwy0p3XqRX/DotR71M5FT5OS/bZCZIKRpEc36TIeKPimZli6voFyX+rsEqVhGenpIKUQ==",
+      "dependencies": {
+        "redis-info": "^3.0.8"
+      }
+    },
+    "node_modules/@bull-board/koa": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@bull-board/koa/-/koa-5.0.0.tgz",
+      "integrity": "sha512-WlUWeKnLIzpUYs72l/XW/PTLPKKqVFzcyhOHglqS89jXNB84gsUHTXkVy6QlSxu3/Aze7lB2Z3IO8u6hhzqfaA==",
+      "dependencies": {
+        "@bull-board/api": "5.0.0",
+        "@bull-board/ui": "5.0.0",
+        "ejs": "^3.1.7",
+        "koa": "^2.13.1",
+        "koa-mount": "^4.0.0",
+        "koa-router": "^10.0.0",
+        "koa-static": "^5.0.0",
+        "koa-views": "^7.0.1"
+      }
+    },
+    "node_modules/@bull-board/koa/node_modules/koa-router": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-10.1.1.tgz",
+      "integrity": "sha512-z/OzxVjf5NyuNO3t9nJpx7e1oR3FSBAauiwXtMQu4ppcnuNZzTaQ4p21P8A6r2Es8uJJM339oc4oVW+qX7SqnQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@bull-board/ui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-5.0.0.tgz",
+      "integrity": "sha512-WznLX8dGthUWimZDqN5Zft3Axp6SStlI244BhiQYXB7xXZRMgaihNZxh7vgpwg0Osmw/gPFvAI+NFVGc3tvj9g==",
+      "dependencies": {
+        "@bull-board/api": "5.0.0"
+      }
+    },
     "node_modules/@certusone/wormhole-sdk": {
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.9.11.tgz",
@@ -169,6 +165,40 @@
       "dependencies": {
         "@types/long": "^4.0.2",
         "@types/node": "^18.0.3"
+      }
+    },
+    "node_modules/@certusone/wormhole-spydk": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-spydk/-/wormhole-spydk-0.0.1.tgz",
+      "integrity": "sha512-iBQoY3UnmGoWHcbn0FypA6hKsANhdHKi03UN0GPoDAeMY12j8ly+7r462TfLl5f4hOJVQd3UZ2qviohEmdicmg==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.4.4",
+        "protobufjs": "^6.11.2"
+      }
+    },
+    "node_modules/@certusone/wormhole-spydk/node_modules/protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/@colors/colors": {
@@ -401,6 +431,11 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@datastructures-js/queue": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@datastructures-js/queue/-/queue-4.2.3.tgz",
+      "integrity": "sha512-GWVMorC/xi2V2ta+Z/CPgPGHL2ZJozcj48g7y2nIX5GIGZGRrbShSHgvMViJwHJurUzJYOdIdRZnWDRrROFwJA=="
     },
     "node_modules/@ethereumjs/common": {
       "version": "2.6.5",
@@ -1124,6 +1159,71 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
+      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz",
+      "integrity": "sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^7.0.0",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@improbable-eng/grpc-web": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.15.0.tgz",
@@ -1355,6 +1455,11 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@metamask/eth-sig-util": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
@@ -1396,6 +1501,78 @@
         "ethjs-util": "0.1.6",
         "rlp": "^2.2.3"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
@@ -1773,7 +1950,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1790,7 +1967,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1808,13 +1985,13 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
       "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/cookies": {
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
       "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -1826,7 +2003,7 @@
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
       "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -1838,7 +2015,7 @@
       "version": "4.17.33",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
       "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1854,25 +2031,25 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
       "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/koa": {
       "version": "2.13.5",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.5.tgz",
       "integrity": "sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -1888,7 +2065,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/koa": "*"
       }
@@ -1924,7 +2101,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/node": {
       "version": "18.15.0",
@@ -1943,13 +2120,13 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
@@ -1963,7 +2140,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
       "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -1996,6 +2173,27 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "node_modules/@wormhole-foundation/relayer-engine": {
+      "version": "0.1.0",
+      "resolved": "file:..",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bull-board/api": "^5.0.0",
+        "@bull-board/koa": "^5.0.0",
+        "@certusone/wormhole-sdk": "^0.9.11",
+        "@certusone/wormhole-spydk": "^0.0.1",
+        "@datastructures-js/queue": "^4.2.3",
+        "bech32": "^2.0.0",
+        "bullmq": "^3.10.1",
+        "ethers": "^5.7.2",
+        "generic-pool": "^3.9.0",
+        "ioredis": "^5.3.1",
+        "koa": "^2.14.1",
+        "prom-client": "^14.2.0",
+        "typescript": "^4.9.5",
+        "winston": "^3.8.2"
+      }
     },
     "node_modules/@wry/context": {
       "version": "0.7.0",
@@ -2067,6 +2265,11 @@
       "dependencies": {
         "follow-redirects": "^1.14.8"
       }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2155,6 +2358,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/aptos": {
       "version": "1.5.0",
@@ -2290,6 +2498,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+    },
     "node_modules/bip32": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
@@ -2333,6 +2546,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -2447,6 +2665,66 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/bullmq": {
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-3.10.4.tgz",
+      "integrity": "sha512-KHYopaoAJpf9Fe9qMjY2xxbMTqgrEIgfrQr81wU0V/wLf4eijNpjVjGVhfQ/bWuHMmwKY1xgOzSIF3+lmdkiOg==",
+      "dependencies": {
+        "cron-parser": "^4.6.0",
+        "glob": "^8.0.3",
+        "ioredis": "^5.3.0",
+        "lodash": "^4.17.21",
+        "msgpackr": "^1.6.2",
+        "semver": "^7.3.7",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/bullmq/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bullmq/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/bullmq/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/bullmq/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/cache-content-type": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
@@ -2505,6 +2783,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -2576,6 +2862,39 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/condense-newlines": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "integrity": "sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/consolidate": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+      "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
+      "dependencies": {
+        "bluebird": "^3.7.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2736,6 +3055,17 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.8.1.tgz",
+      "integrity": "sha512-jbokKWGcyU4gl6jAfX97E1gDpY12DJ1cLJZmoDzaAln/shZ+S3KBFBuA2Q6WeUN4gJf/8klnV1EfvhA2lK5IRQ==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -2853,6 +3183,14 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2934,10 +3272,46 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -3214,6 +3588,17 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -3236,6 +3621,33 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -3292,6 +3704,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3311,6 +3731,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-paths": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/get-paths/-/get-paths-0.0.7.tgz",
+      "integrity": "sha512-0wdJt7C1XKQxuCgouqd+ZvLJ56FQixKoki9MrFaO4EriqzXOiH9gbukaDE1ou08S8Ns3/yDzoBAISNPqj6e6tA==",
+      "dependencies": {
+        "pify": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6.4"
       }
     },
     "node_modules/glob": {
@@ -3554,6 +3985,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -3562,10 +3998,38 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.1.tgz",
+      "integrity": "sha512-C+IBcMysM6v52pTLItYMeV4Hz7uriGtoJdz7SSBDX6u+zwSYGirLdQh3L7t/OItWITcw3gTFMjJReYUwS4zihg==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-core-module": {
       "version": "2.11.0",
@@ -3576,6 +4040,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -3620,6 +4092,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3631,6 +4111,87 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "peerDependencies": {
         "ws": "*"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jake/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jake/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jayson": {
@@ -3668,6 +4229,62 @@
       "version": "3.7.5",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
       "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
+    },
+    "node_modules/js-beautify": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
+      "integrity": "sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^8.0.3",
+        "nopt": "^6.0.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/js-sha256": {
       "version": "0.9.0",
@@ -3776,6 +4393,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/koa": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.14.1.tgz",
@@ -3826,6 +4454,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/koa-mount": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/koa-mount/-/koa-mount-4.0.0.tgz",
+      "integrity": "sha512-rm71jaA/P+6HeCpoRhmCv8KVBIi0tfGuO/dMKicbQnQW/YJntJ6MnnspkodoA4QstMVEZArsCphmd0bJEtoMjQ==",
+      "dependencies": {
+        "debug": "^4.0.1",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
     "node_modules/koa-router": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-12.0.0.tgz",
@@ -3861,6 +4501,61 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/koa-send": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
+      "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "resolve-path": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/koa-static": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
+      "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "koa-send": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/koa-static/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/koa-views": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/koa-views/-/koa-views-7.0.2.tgz",
+      "integrity": "sha512-dvx3mdVeSVuIPEaKAoGbxLcenudvhl821xxyuRbcoA+bOJ2dvN8wlGjkLu0ZFMlkCscXZV6lzxy28rafeazI/w==",
+      "dependencies": {
+        "consolidate": "^0.16.0",
+        "debug": "^4.1.0",
+        "get-paths": "0.0.7",
+        "koa-send": "^5.0.0",
+        "mz": "^2.4.0",
+        "pretty": "^2.0.0",
+        "resolve-path": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/koa": "^2.13.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/koa": {
+          "optional": true
+        }
       }
     },
     "node_modules/kuler": {
@@ -3899,6 +4594,21 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.values": {
       "version": "4.3.0",
@@ -3940,6 +4650,23 @@
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/map-obj": {
@@ -4043,12 +4770,51 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msgpackr": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
+      "integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.1"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.7"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
+      }
+    },
     "node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "bin": {
         "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "node_modules/nan": {
@@ -4125,6 +4891,17 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
     "node_modules/node-redis": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/node-redis/-/node-redis-0.1.7.tgz",
@@ -4155,6 +4932,20 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
+    "node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/o3": {
       "version": "1.0.3",
@@ -4267,6 +5058,14 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
@@ -4282,10 +5081,34 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
+      "integrity": "sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==",
+      "dependencies": {
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/prom-client": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4296,6 +5119,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
     "node_modules/protobufjs": {
       "version": "7.2.2",
@@ -4324,6 +5152,11 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -4367,6 +5200,33 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-info": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redis-info/-/redis-info-3.1.0.tgz",
+      "integrity": "sha512-ER4L9Sh/vm63DkIE0bkSjxluQlioBiBgf5w1UuldaW/3vPcecdljVDisZhmnCMvsxHNiARTTDDHGg9cGwTfrKg==",
+      "dependencies": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -4395,6 +5255,50 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/resolve-path": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
+      "integrity": "sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==",
+      "dependencies": {
+        "http-errors": "~1.6.2",
+        "path-is-absolute": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-path/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
+    "node_modules/resolve-path/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "node_modules/response-iterator": {
       "version": "0.2.6",
@@ -4539,6 +5443,36 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -4600,6 +5534,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -4637,6 +5576,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -4730,6 +5674,14 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
@@ -4739,6 +5691,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -4903,6 +5874,18 @@
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/u3": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/u3/-/u3-0.1.1.tgz",
@@ -5010,10 +5993,6 @@
         "node": ">= 6.4.0"
       }
     },
-    "node_modules/wormhole-relayer": {
-      "resolved": "..",
-      "link": true
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -5117,6 +6096,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/yargs": {
       "version": "17.7.1",

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -14,7 +14,7 @@
     "koa-router": "^12.0.0",
     "node-redis": "^0.1.7",
     "winston": "^3.8.2",
-    "wormhole-relayer": "file:../",
+    "@wormhole-foundation/relayer-engine": "file:../",
     "yargs": "^17.7.1"
   },
   "keywords": [],

--- a/example-app/src/app.ts
+++ b/example-app/src/app.ts
@@ -106,7 +106,7 @@ function runUI(
       return;
     }
 
-    ctx.body = await relayer.metricsRegistry().metrics();
+    ctx.body = await store.registry.metrics();
   });
 
   port = Number(port) || 3000;

--- a/example-app/src/controller.ts
+++ b/example-app/src/controller.ts
@@ -1,4 +1,4 @@
-import { Next } from "wormhole-relayer";
+import { Next } from "@wormhole-foundation/relayer-engine";
 import { MyRelayerContext } from "./app";
 
 export class ApiController {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "wormhole-relayer",
-  "version": "0.0.1",
+  "name": "@wormhole-foundation/relayer-engine",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wormhole-relayer",
-      "version": "0.0.1",
-      "license": "ISC",
+      "name": "@wormhole-foundation/relayer-engine",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bull-board/api": "^5.0.0",
         "@bull-board/koa": "^5.0.0",

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -139,6 +139,10 @@ export class StandardRelayerApp<
     return this.store.registry;
   }
 
+  /**
+   * A UI that you can mount in a KOA app to show the status of the queue / jobs.
+   * @param path
+   */
   storageKoaUI(path: string) {
     // UI
     const serverAdapter = new KoaAdapter();

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -126,6 +126,19 @@ export class StandardRelayerApp<
     }
   }
 
+  /**
+   * Registry with prometheus metrics exported by the relayer.
+   * Metrics include:
+   * - active_workflows: Number of workflows currently running
+   * - delayed_workflows: Number of worklows which are scheduled in the future either because they were scheduled that way or because they failed.
+   * - waiting_workflows: Workflows waiting for a worker to pick them up.
+   * - worklow_processing_duration: Processing time for completed jobs (processing until completed)
+   * - workflow_total_duration: Processing time for completed jobs (processing until completed)
+   */
+  get metricsRegistry() {
+    return this.store.registry;
+  }
+
   storageKoaUI(path: string) {
     // UI
     const serverAdapter = new KoaAdapter();

--- a/relayer/application.ts
+++ b/relayer/application.ts
@@ -463,6 +463,3 @@ export type ContractFilter = {
   emitterAddress: string; // Emitter contract address to filter for
   chainId: ChainId; // Wormhole ChainID to filter for
 };
-
-/**
- */

--- a/relayer/application.ts
+++ b/relayer/application.ts
@@ -398,19 +398,6 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
   }
 
   /**
-   * Registry with prometheus metrics exported by the relayer.
-   * Metrics include:
-   * - active_workflows: Number of workflows currently running
-   * - delayed_workflows: Number of worklows which are scheduled in the future either because they were scheduled that way or because they failed.
-   * - waiting_workflows: Workflows waiting for a worker to pick them up.
-   * - worklow_processing_duration: Processing time for completed jobs (processing until completed)
-   * - workflow_total_duration: Processing time for completed jobs (processing until completed)
-   */
-  get metricsRegistry() {
-    return this.storage?.registry;
-  }
-
-  /**
    * Stop the worker from grabbing more jobs and wait until it finishes with the ones that it has.
    */
   stop() {
@@ -418,17 +405,6 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
   }
 
   private onVaaFromQueue = async (job: RelayJob) => {
-    let parsedVaa = job.data?.parsedVaa;
-    if (parsedVaa) {
-      this.rootLogger?.debug(`Starting job: ${job.id}`, {
-        emitterChain: parsedVaa.emitterChain,
-        emitterAddress: parsedVaa.emitterAddress.toString("hex"),
-        sequence: parsedVaa.sequence.toString(),
-      });
-    } else {
-      this.rootLogger.debug("Received job with no parsedVaa");
-    }
-    await job.log(`processing by..${this.storage.workerId}`);
     await this.pushVaaThroughPipeline(job.data.vaaBytes, {
       storage: {
         job,

--- a/relayer/application.ts
+++ b/relayer/application.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events";
-import * as wormholeSdk from "@certusone/wormhole-sdk";
 import {
   ChainId,
   ChainName,
@@ -36,6 +35,7 @@ import * as grpcWebNodeHttpTransport from "@improbable-eng/grpc-web-node-http-tr
 import { defaultLogger } from "./logging";
 import { VaaBundleFetcher, VaaId } from "./bundle-fetcher.helper";
 import { RelayJob, Storage } from "./storage/storage";
+import * as Events from "events";
 
 export enum Environment {
   MAINNET = "mainnet",
@@ -71,9 +71,30 @@ const defaultOpts = (env: Environment): RelayerAppOpts => ({
   concurrency: 1,
 });
 
+interface SerializableVaaId {
+  emitterChain: ChainId;
+  emitterAddress: string;
+  sequence: string;
+}
+
 export interface ParsedVaaWithBytes extends ParsedVaa {
+  id: SerializableVaaId;
   bytes: SignedVaa;
 }
+
+export type FilterFN = (
+  vaaBytes: ParsedVaaWithBytes,
+) => Promise<boolean> | boolean;
+
+export enum RelayerEvents {
+  Received = "received",
+  Added = "added",
+  Skipped = "skipped",
+  Completed = "completed",
+  Failed = "failed",
+}
+
+export type ListenerFn = (vaa: ParsedVaaWithBytes, job?: RelayJob) => void;
 
 export class RelayerApp<ContextT extends Context> extends EventEmitter {
   private pipeline?: Middleware;
@@ -84,8 +105,9 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
   storage: Storage;
   filters: {
     emitterFilter?: { chainId?: ChainID; emitterAddress?: string };
-  }[];
+  }[] = [];
   private opts: RelayerAppOpts;
+  private vaaFilters: FilterFN[] = [];
 
   constructor(
     public env: Environment = Environment.TESTNET,
@@ -93,6 +115,69 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
   ) {
     super();
     this.opts = mergeDeep({}, [defaultOpts(env), opts]);
+  }
+
+  /**
+   *  This function will run as soon as a VAA is received and will determine whether we want to process it or skip it.
+   *  This is useful if you're listening to a contract but you don't care about every one of the VAAs emitted by it (eg. The Token Bridge contract).
+   *
+   *  WARNING: If your function throws, the VAA will be skipped (is this the right behavior?). If you want to process the VAA anyway, catch your errors and return true.
+   *
+   * @param newFilter pass in a function that will receive the raw bytes of the VAA and if it returns `true` or `Promise<true>` the VAA will be processed, otherwise it will be skipped
+   */
+  filter(newFilter: FilterFN) {
+    this.vaaFilters.push(newFilter);
+  }
+
+  private async shouldProcessVaa(vaa: ParsedVaaWithBytes): Promise<boolean> {
+    if (this.vaaFilters.length === 0) {
+      return true;
+    }
+    for (let i = 0; i < this.vaaFilters.length; i++) {
+      const chain = vaa.emitterChain;
+      const emitterAddress = vaa.emitterAddress.toString("hex");
+      const sequence = vaa.sequence.toString();
+
+      const filter = this.vaaFilters[i];
+      let isOk;
+      try {
+        isOk = await filter(vaa);
+      } catch (e: any) {
+        isOk = false;
+        this.rootLogger.debug(
+          `filter ${i} of ${this.vaaFilters.length} threw an exception`,
+          {
+            chain,
+            emitterAddress,
+            sequence,
+            message: e.message,
+            stack: e.stack,
+            name: e.name,
+          },
+        );
+      }
+      if (!isOk) {
+        this.rootLogger.debug(
+          `Vaa was skipped by filter ${i} of ${this.vaaFilters.length}`,
+          { chain, emitterAddress, sequence },
+        );
+        return false;
+      }
+    }
+    return true;
+  }
+
+  on(eventName: RelayerEvents, listener: ListenerFn): this {
+    return super.on(eventName, listener);
+  }
+
+  emit(
+    eventName: RelayerEvents,
+    vaa: ParsedVaaWithBytes,
+    job?: RelayJob,
+    ...args: any
+  ): boolean {
+    return super.emit(eventName, vaa, job, ...args);
   }
 
   /**
@@ -197,13 +282,26 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
   /**
    * processVaa allows you to put a VAA through the pipeline leveraging storage if needed.
    * @param vaa
-   * @param opts
+   * @param opts You can use this to extend the context that will be passed to the middleware
    */
-  async processVaa(vaa: Buffer, opts?: any) {
+  async processVaa(vaa: Buffer, opts: any = {}) {
+    let parsedVaa = parseVaaWithBytes(vaa);
+    this.emit(RelayerEvents.Received, parsedVaa);
+    if (!(await this.shouldProcessVaa(parsedVaa)) && !opts.force) {
+      this.rootLogger?.debug("VAA did not pass filters. Skipping...", {
+        emitterChain: parsedVaa.emitterChain,
+        emitterAddress: parsedVaa.emitterAddress.toString("hex"),
+        sequence: parsedVaa.sequence.toString(),
+      });
+      this.emit(RelayerEvents.Skipped, parsedVaa);
+      return;
+    }
     if (this.storage) {
-      await this.storage.addVaaToQueue(vaa);
+      const job = await this.storage.addVaaToQueue(parsedVaa.bytes);
+      this.emit(RelayerEvents.Added, parsedVaa, job);
     } else {
-      this.pushVaaThroughPipeline(vaa);
+      this.emit(RelayerEvents.Added, parsedVaa);
+      await this.pushVaaThroughPipeline(vaa, opts);
     }
   }
 
@@ -212,25 +310,33 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
    * @param vaa
    * @param opts
    */
-  async pushVaaThroughPipeline(vaa: Buffer, opts?: any): Promise<void> {
-    const parsedVaa = wormholeSdk.parseVaa(vaa);
+  private async pushVaaThroughPipeline(
+    vaa: SignedVaa,
+    opts: any,
+  ): Promise<void> {
+    const parsedVaa = parseVaaWithBytes(vaa);
+    const job: RelayJob | undefined = opts.job;
+
     let ctx: Context = {
-      vaa: parsedVaa,
-      vaaBytes: vaa,
-      env: this.env,
-      fetchVaa: this.fetchVaa.bind(this),
-      fetchVaas: this.fetchVaas.bind(this),
-      processVaa: this.processVaa.bind(this),
       config: {
         spyFilters: await this.spyFilters(),
       },
+      env: this.env,
+      fetchVaa: this.fetchVaa.bind(this),
+      fetchVaas: this.fetchVaas.bind(this),
       locals: {},
+      on: this.on.bind(this),
+      processVaa: this.processVaa.bind(this),
+      vaa: parsedVaa,
+      vaaBytes: vaa,
     };
-    Object.assign(ctx, opts);
+    Object.assign(ctx, opts, { storage: { job } });
     try {
       await this.pipeline?.(ctx, () => {});
+      this.emit(RelayerEvents.Completed, parsedVaa, job);
     } catch (e) {
       this.errorPipeline?.(e, ctx, () => {});
+      this.emit(RelayerEvents.Failed, parsedVaa, job);
       throw e;
     }
   }
@@ -260,7 +366,7 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
    *
    * Would run middleware1 and middleware2 for any tokenBridge vaa coming from ethereum or solana.
    *
-   * @param chains
+   * @param chainsOrChain
    * @param handlers
    */
   tokenBridge(
@@ -285,7 +391,7 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
     { emitterFilter?: { chainId?: ChainID; emitterAddress?: string } }[]
   > {
     const spyFilters = new Set<any>();
-    for (const [chainId, chainRouter] of Object.entries(this.chainRouters)) {
+    for (const chainRouter of Object.values(this.chainRouters)) {
       for (const filter of await chainRouter.spyFilters()) {
         spyFilters.add(filter);
       }
@@ -335,19 +441,14 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
    * Configure your storage by passing info redis connection info among other details.
    * If you are using RelayerApp<any>, and you do not call this method, you will not be using storage.
    * Which means your VAAS will go straight through the pipeline instead of being added to a queue.
-   * @param storageOptions
+   * @param storage
    */
   useStorage(storage: Storage) {
     this.storage = storage;
   }
 
-  /**
-   * A UI that you can mount in a KOA app to show the status of the queue / jobs.
-   * @param path
-   */
-
   private generateChainRoutes(): Middleware<ContextT> {
-    let chainRouting = async (ctx: ContextT, next: Next) => {
+    return async (ctx: ContextT, next: Next) => {
       let router = this.chainRouters[ctx.vaa.emitterChain as ChainId];
       if (!router) {
         this.rootLogger.error(
@@ -357,7 +458,6 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
       }
       await router.process(ctx, next);
     };
-    return chainRouting;
   }
 
   /**
@@ -387,7 +487,7 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
 
         for await (const vaa of stream) {
           this.rootLogger.debug(`Received VAA through spy`);
-          this.processVaa(vaa.vaaBytes).catch();
+          this.processVaa(vaa.vaaBytes);
         }
       } catch (err) {
         this.rootLogger.error("error connecting to the spy");
@@ -405,11 +505,7 @@ export class RelayerApp<ContextT extends Context> extends EventEmitter {
   }
 
   private onVaaFromQueue = async (job: RelayJob) => {
-    await this.pushVaaThroughPipeline(job.data.vaaBytes, {
-      storage: {
-        job,
-      },
-    });
+    await this.pushVaaThroughPipeline(job.data.vaaBytes, { storage: { job } });
     await job.updateProgress(100);
     return [""];
   };
@@ -443,10 +539,9 @@ class ChainRouter<ContextT extends Context> {
 
   spyFilters(): { emitterFilter: ContractFilter }[] {
     let addresses = Object.keys(this._addressHandlers);
-    const filters = addresses.map(address => ({
+    return addresses.map(address => ({
       emitterFilter: { chainId: this.chainId, emitterAddress: address },
     }));
-    return filters;
   }
 
   async process(ctx: ContextT, next: Next): Promise<void> {

--- a/relayer/compose.middleware.ts
+++ b/relayer/compose.middleware.ts
@@ -5,7 +5,7 @@ export type Middleware<ContextT extends Context = Context> = (
   ctx: ContextT,
   next: Next,
 ) => Promise<void>;
-export type ErrorMiddleware<ContextT extends Context> = (
+export type ErrorMiddleware<ContextT extends Context = Context> = (
   err: Error,
   ctx: ContextT,
   next: Next,

--- a/relayer/context.ts
+++ b/relayer/context.ts
@@ -1,7 +1,14 @@
-import { ChainId, ParsedVaa } from "@certusone/wormhole-sdk";
-import { Environment, FetchaVaasOpts, ParsedVaaWithBytes } from "./application";
+import { ChainId, SignedVaa } from "@certusone/wormhole-sdk";
+import {
+  Environment,
+  RelayerEvents,
+  FetchaVaasOpts,
+  ParsedVaaWithBytes,
+  ListenerFn,
+} from "./application";
 import { Logger } from "winston";
 import { ChainID } from "@certusone/wormhole-spydk/lib/cjs/proto/publicrpc/v1/publicrpc";
+import { RelayJob } from "./storage/storage";
 
 export type FetchVaaFn = (
   emitterChain: ChainId | string,
@@ -14,14 +21,15 @@ export type FetchVaasFn = (
 ) => Promise<ParsedVaaWithBytes[]>;
 
 export interface Context {
-  vaa?: ParsedVaa;
-  vaaBytes?: Buffer;
+  vaa?: ParsedVaaWithBytes;
+  vaaBytes?: SignedVaa;
   locals: Record<any, any>;
   fetchVaa: FetchVaaFn;
   fetchVaas: FetchVaasFn;
   processVaa: (vaa: Buffer) => Promise<void>;
   env: Environment;
   logger?: Logger;
+  on: (eventName: RelayerEvents, listener: ListenerFn) => void;
   config: {
     spyFilters: {
       emitterFilter?: { chainId?: ChainID; emitterAddress?: string };

--- a/relayer/index.ts
+++ b/relayer/index.ts
@@ -2,7 +2,7 @@ export * from "./application";
 export * from "./application-standard";
 export * from "./context";
 export * from "./compose.middleware";
-export * from "./storage";
+export * from "./storage/storage";
 export * from "./logging";
 export * from "./middleware";
 export * from "./utils";

--- a/relayer/middleware/legacy-plugin/legacy-plugin.middleware.ts
+++ b/relayer/middleware/legacy-plugin/legacy-plugin.middleware.ts
@@ -10,15 +10,11 @@ import {
   Providers as LegacyProviders,
 } from "./legacy-plugin-definition";
 import * as legacy from "./legacy-plugin-definition";
-import { StorageContext } from "../../storage";
+import { StorageContext } from "../../storage/storage";
 import { LoggingContext } from "../logger.middleware";
 import { StagingAreaContext } from "../staging-area.middleware";
 import { ProviderContext, Providers } from "../providers.middleware";
-import {
-  SolanaWallet,
-  Wallet,
-  WalletContext,
-} from "../wallet/wallet.middleware";
+import { SolanaWallet, Wallet, WalletContext } from "../wallet";
 import { EVMWallet, WalletToolBox } from "../wallet";
 import { Connection } from "@solana/web3.js";
 

--- a/relayer/middleware/metrics.middleware.ts
+++ b/relayer/middleware/metrics.middleware.ts
@@ -1,7 +1,6 @@
-import { Logger } from "winston";
 import { Middleware } from "../compose.middleware";
 import { Context } from "../context";
-import { StorageContext } from "../storage";
+import { StorageContext } from "../storage/storage";
 import { Job } from "bullmq";
 import { Counter } from "prom-client";
 

--- a/relayer/middleware/tokenBridge.middleware.ts
+++ b/relayer/middleware/tokenBridge.middleware.ts
@@ -8,6 +8,7 @@ import {
   ParsedTokenTransferVaa,
   ParsedVaa,
   parseTokenTransferVaa,
+  SignedVaa,
 } from "@certusone/wormhole-sdk";
 import { ethers, Signer } from "ethers";
 import { ProviderContext } from "./providers.middleware";
@@ -101,7 +102,7 @@ function isTokenBridgeVaa(env: Environment, vaa: ParsedVaa): boolean {
 }
 
 function tryToParseTokenTransferVaa(
-  vaaBytes: Buffer,
+  vaaBytes: SignedVaa,
 ): ParsedTokenTransferVaa | null {
   try {
     return parseTokenTransferVaa(vaaBytes);

--- a/relayer/storage/redis-storage.ts
+++ b/relayer/storage/redis-storage.ts
@@ -167,14 +167,14 @@ export class RedisStorage implements Storage {
 
         const vaaBytes = Buffer.from(job.data.vaaBytes, "base64");
         const relayJob: RelayJob = {
-          attempts: 0,
+          attempts: job.attemptsMade,
           data: {
             vaaBytes,
             parsedVaa: parseVaa(vaaBytes),
           },
-          id: "",
-          maxAttempts: 0,
-          name: "",
+          id: job.id,
+          maxAttempts: this.opts.attempts,
+          name: job.name,
           log: job.log.bind(job),
           updateProgress: job.updateProgress.bind(job),
         };

--- a/relayer/storage/storage.ts
+++ b/relayer/storage/storage.ts
@@ -24,9 +24,7 @@ export interface RelayJob {
 export type onJobHandler = (job: RelayJob) => Promise<any>;
 
 export interface Storage {
-  workerId: string;
   addVaaToQueue(vaa: Buffer): Promise<any>;
   startWorker(cb: onJobHandler): void;
   stopWorker(): Promise<void>;
-  registry: Registry;
 }

--- a/relayer/storage/storage.ts
+++ b/relayer/storage/storage.ts
@@ -1,6 +1,6 @@
 import { Registry } from "prom-client";
 import { Context } from "../context";
-import { ParsedVaa } from "@certusone/wormhole-sdk";
+import { ParsedVaa, SignedVaa } from "@certusone/wormhole-sdk";
 
 export interface StorageContext extends Context {
   storage: {
@@ -24,7 +24,7 @@ export interface RelayJob {
 export type onJobHandler = (job: RelayJob) => Promise<any>;
 
 export interface Storage {
-  addVaaToQueue(vaa: Buffer): Promise<any>;
+  addVaaToQueue(vaa: SignedVaa): Promise<RelayJob>;
   startWorker(cb: onJobHandler): void;
   stopWorker(): Promise<void>;
 }

--- a/relayer/storage/storage.ts
+++ b/relayer/storage/storage.ts
@@ -1,0 +1,32 @@
+import { Registry } from "prom-client";
+import { Context } from "../context";
+import { ParsedVaa } from "@certusone/wormhole-sdk";
+
+export interface StorageContext extends Context {
+  storage: {
+    job: RelayJob;
+  };
+}
+
+export interface RelayJob {
+  id: string;
+  name: string;
+  data: {
+    vaaBytes: Buffer;
+    parsedVaa: ParsedVaa;
+  };
+  attempts: number;
+  maxAttempts: number;
+  log(logRow: string): Promise<number>;
+  updateProgress(progress: number | object): Promise<void>;
+}
+
+export type onJobHandler = (job: RelayJob) => Promise<any>;
+
+export interface Storage {
+  workerId: string;
+  addVaaToQueue(vaa: Buffer): Promise<any>;
+  startWorker(cb: onJobHandler): void;
+  stopWorker(): Promise<void>;
+  registry: Registry;
+}

--- a/relayer/utils.ts
+++ b/relayer/utils.ts
@@ -57,7 +57,12 @@ export function isObject(item: any) {
 
 export function parseVaaWithBytes(bytes: SignedVaa): ParsedVaaWithBytes {
   const parsedVaa = parseVaa(bytes);
-  return { ...parsedVaa, bytes };
+  const id = {
+    emitterChain: parsedVaa.emitterChain as ChainId,
+    emitterAddress: parsedVaa.emitterAddress.toString("hex"),
+    sequence: parsedVaa.sequence.toString(),
+  };
+  return { ...parsedVaa, bytes, id };
 }
 
 /**


### PR DESCRIPTION
Motivation: To most integrators, this won't make a difference. They'll be using the `StandardRelayerApp` which hides everything behind the same interface. However, it opens the door to anybody that wants to leverage their own storage solution (SQS, Postgres, etc). And it's on them to then implement middleware that uses their same db if they want to avoid having to run multiple databases.

The change is to avoid locking people to redis, even if that's what we use and recommend using publicly. We will not provide an alternative storage backend for now.