### PR TITLE
Fix defaultOpts logger bug

### DIFF
--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -62,7 +62,7 @@ export class StandardRelayerApp<
   private store: RedisStorage;
   constructor(env: Environment, opts: StandardRelayerAppOpts) {
     // take logger out before merging because of recursive call stack
-    const logger = opts.logger;
+    const logger = opts.logger ?? defaultLogger;
     delete opts.logger;
     // now we can merge
     opts = mergeDeep({}, [defaultOpts, opts]);


### PR DESCRIPTION
If the user does not supply a logger in `opts` while creating a `StandardRelayerApp`, e.g.
```
const app = new StandardRelayerApp<MyRelayerContext>(env, opts);
```

Then VAA processing will fail due to the following error:
```
TypeError: Cannot read properties of undefined (reading 'child')
    at /home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/middleware/logger.middleware.ts:12:16
    at callNext (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:23:14)
    at /home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:25:12
    at callNext (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:23:14)
    at /home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:25:12
    at callNext (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:23:14)
    at /home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:25:12
    at callNext (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:23:14)
    at /home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:25:12
    at callNext (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:23:14)
    at /home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:25:12
    at callNext (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:23:14)
    at /home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:25:12
    at callNext (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:23:14)
    at StandardRelayerApp.pipeline (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/compose.middleware.ts:25:12)
    at StandardRelayerApp.pushVaaThroughPipeline (/home/nsuri/example-sei-relayer/node_modules/@wormhole-foundation/relayer-engine/relayer/application.ts:333:28)
```

This happens because the `StandardRelayerApp` does not re-read the default logger from the merged `opts` during instantiation.