### PR TITLE
Allow tokens to be passed as options

### DIFF
--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -33,7 +33,7 @@ export interface StandardRelayerAppOpts extends RelayerAppOpts {
   }>;
   tokenAddresses?: Partial<{
     [k in ChainId]: any[];
-  }>
+  }>;
   workflows?: {
     retries: number;
   };

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -31,6 +31,9 @@ export interface StandardRelayerAppOpts extends RelayerAppOpts {
   privateKeys?: Partial<{
     [k in ChainId]: any[];
   }>;
+  tokenAddresses?: Partial<{
+    [k in ChainId]: any[];
+  }>
   workflows?: {
     retries: number;
   };
@@ -70,6 +73,7 @@ export class StandardRelayerApp<
 
     const {
       privateKeys,
+      tokenAddresses,
       name,
       spyEndpoint,
       redis,
@@ -109,6 +113,7 @@ export class StandardRelayerApp<
           logger,
           namespace: name,
           privateKeys,
+          tokenAddresses,
           metrics: { enabled: true, registry: this.metricsRegistry },
         }),
       ); // <-- you need valid private keys to turn on this middleware

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -23,6 +23,7 @@ import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
 import { KoaAdapter } from "@bull-board/koa";
 import { createBullBoard } from "@bull-board/api";
 import { Environment } from "./environment";
+import { TokensByChain } from "./middleware/wallet/wallet-management";
 
 export interface StandardRelayerAppOpts extends RelayerAppOpts {
   name: string;
@@ -31,9 +32,7 @@ export interface StandardRelayerAppOpts extends RelayerAppOpts {
   privateKeys?: Partial<{
     [k in ChainId]: any[];
   }>;
-  tokenAddresses?: Partial<{
-    [k in ChainId]: any[];
-  }>;
+  tokensByChain?: TokensByChain;
   workflows?: {
     retries: number;
   };
@@ -73,7 +72,7 @@ export class StandardRelayerApp<
 
     const {
       privateKeys,
-      tokenAddresses,
+      tokensByChain,
       name,
       spyEndpoint,
       redis,
@@ -113,7 +112,7 @@ export class StandardRelayerApp<
           logger,
           namespace: name,
           privateKeys,
-          tokenAddresses,
+          tokensByChain,
           metrics: { enabled: true, registry: this.metricsRegistry },
         }),
       ); // <-- you need valid private keys to turn on this middleware

--- a/relayer/middleware/wallet/wallet-management.ts
+++ b/relayer/middleware/wallet/wallet-management.ts
@@ -62,15 +62,16 @@ const networks = {
 };
 
 export type PrivateKeys = Partial<{ [k in ChainId]: string[] }>;
-export type TokenAddresses = Partial<{ [k in ChainId]: string[] }>;
+export type TokensByChain = Partial<{ [k in ChainId]: string[] }>;
 
 function buildWalletsConfig(
   env: Environment,
   privateKeys: PrivateKeys,
-  tokenAddresses: TokenAddresses,
+  tokensByChain?: TokensByChain,
 ): WalletManagerConfig {
   const networkByChain: any = networks[env];
   const config: WalletManagerConfig = {};
+  const tokens = tokensByChain ?? {};
   for (const [chainIdStr, keys] of Object.entries(privateKeys)) {
     const chainId = Number(chainIdStr) as ChainId;
     const chainName = coalesceChainName(chainId);
@@ -80,7 +81,7 @@ function buildWalletsConfig(
       for (const key of keys) {
         chainWallets.push({
           privateKey: key,
-          tokens: tokenAddresses[chainId],
+          tokens: tokens[chainId] ?? [],
         });
       }
     } else if (CHAIN_ID_SOLANA === chainId) {
@@ -96,14 +97,14 @@ function buildWalletsConfig(
 
         chainWallets.push({
           privateKey: secretKey.toString(),
-          tokens: tokenAddresses[chainId],
+          tokens: tokens[chainId] ?? [],
         });
       }
     } else if (chainId === CHAIN_ID_SUI) {
       for (const key of keys) {
         chainWallets.push({
           privateKey: key,
-          tokens: tokenAddresses[chainId],
+          tokens: tokens[chainId] ?? [],
         });
       }
     }
@@ -119,11 +120,11 @@ function buildWalletsConfig(
 export function startWalletManagement(
   env: Environment,
   privateKeys: PrivateKeys,
-  tokenAddresses: TokenAddresses,
-  metricsOpts: WalletManagerOptions["metrics"],
+  tokensByChain?: TokensByChain,
+  metricsOpts?: WalletManagerOptions["metrics"],
   logger?: Logger,
 ) {
-  const wallets = buildWalletsConfig(env, privateKeys, tokenAddresses);
+  const wallets = buildWalletsConfig(env, privateKeys, tokensByChain);
 
   const manager = new WalletManager(wallets, {
     logger: logger?.child({ module: "wallet-manager" }),

--- a/relayer/middleware/wallet/wallet-management.ts
+++ b/relayer/middleware/wallet/wallet-management.ts
@@ -62,10 +62,12 @@ const networks = {
 };
 
 export type PrivateKeys = Partial<{ [k in ChainId]: string[] }>;
+export type TokenAddresses = Partial<{ [k in ChainId]: string[] }>;
 
 function buildWalletsConfig(
   env: Environment,
   privateKeys: PrivateKeys,
+  tokenAddresses: TokenAddresses,
 ): WalletManagerConfig {
   const networkByChain: any = networks[env];
   const config: WalletManagerConfig = {};
@@ -78,6 +80,7 @@ function buildWalletsConfig(
       for (const key of keys) {
         chainWallets.push({
           privateKey: key,
+          tokens: tokenAddresses[chainId],
         });
       }
     } else if (CHAIN_ID_SOLANA === chainId) {
@@ -93,12 +96,14 @@ function buildWalletsConfig(
 
         chainWallets.push({
           privateKey: secretKey.toString(),
+          tokens: tokenAddresses[chainId],
         });
       }
     } else if (chainId === CHAIN_ID_SUI) {
       for (const key of keys) {
         chainWallets.push({
           privateKey: key,
+          tokens: tokenAddresses[chainId],
         });
       }
     }
@@ -114,10 +119,11 @@ function buildWalletsConfig(
 export function startWalletManagement(
   env: Environment,
   privateKeys: PrivateKeys,
+  tokenAddresses: TokenAddresses,
   metricsOpts: WalletManagerOptions["metrics"],
   logger?: Logger,
 ) {
-  const wallets = buildWalletsConfig(env, privateKeys);
+  const wallets = buildWalletsConfig(env, privateKeys, tokenAddresses);
 
   const manager = new WalletManager(wallets, {
     logger: logger?.child({ module: "wallet-manager" }),

--- a/relayer/middleware/wallet/wallet.middleware.ts
+++ b/relayer/middleware/wallet/wallet.middleware.ts
@@ -14,7 +14,7 @@ import { spawnWalletWorker } from "./wallet.worker";
 import { Queue } from "@datastructures-js/queue";
 import { ProviderContext, UntypedProvider } from "../providers.middleware";
 import { Logger } from "winston";
-import { startWalletManagement } from "./wallet-management";
+import { TokensByChain, startWalletManagement } from "./wallet-management";
 import { Registry } from "prom-client";
 import { Environment } from "../../environment";
 
@@ -106,9 +106,7 @@ export interface WalletOpts {
   privateKeys: Partial<{
     [k in ChainId]: any[];
   }>;
-  tokenAddresses: Partial<{
-    [k in ChainId]: any[];
-  }>;
+  tokensByChain?: TokensByChain;
   logger?: Logger;
   metrics?: {
     enabled: boolean;
@@ -138,9 +136,9 @@ export function wallets(
     startWalletManagement(
       env,
       opts.privateKeys,
-      opts.tokenAddresses,
+      opts.tokensByChain,
       opts.metrics,
-      opts.logger
+      opts.logger,
     );
   }
 

--- a/relayer/middleware/wallet/wallet.middleware.ts
+++ b/relayer/middleware/wallet/wallet.middleware.ts
@@ -106,6 +106,9 @@ export interface WalletOpts {
   privateKeys: Partial<{
     [k in ChainId]: any[];
   }>;
+  tokenAddresses: Partial<{
+    [k in ChainId]: any[];
+  }>;
   logger?: Logger;
   metrics?: {
     enabled: boolean;
@@ -132,7 +135,7 @@ export function wallets(
   );
 
   if (opts.metrics) {
-    startWalletManagement(env, opts.privateKeys, opts.metrics, opts.logger);
+    startWalletManagement(env, opts.privateKeys, opts.tokenAddresses, opts.metrics, opts.logger);
   }
 
   let executeFunction: ActionExecutor;

--- a/relayer/middleware/wallet/wallet.middleware.ts
+++ b/relayer/middleware/wallet/wallet.middleware.ts
@@ -135,7 +135,13 @@ export function wallets(
   );
 
   if (opts.metrics) {
-    startWalletManagement(env, opts.privateKeys, opts.tokenAddresses, opts.metrics, opts.logger);
+    startWalletManagement(
+      env,
+      opts.privateKeys,
+      opts.tokenAddresses,
+      opts.metrics,
+      opts.logger
+    );
   }
 
   let executeFunction: ActionExecutor;


### PR DESCRIPTION
Allows tokens to be passed to the wallet middleware so it can get metrics on specific tokens using the `tokens` param from WalletManager