### PR TITLE
Fix SeiWallet to use DirectSecp256k1HdWallet instead of AccountData

### DIFF
--- a/relayer/middleware/wallet/wallet.middleware.ts
+++ b/relayer/middleware/wallet/wallet.middleware.ts
@@ -18,11 +18,11 @@ import { Logger } from "winston";
 import { TokensByChain, startWalletManagement } from "./wallet-management";
 import { Registry } from "prom-client";
 import { Environment } from "../../environment";
-import { AccountData } from "@cosmjs/proto-signing";
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 
 export type EVMWallet = ethers.Wallet;
 export type SuiWallet = sui.RawSigner;
-export type SeiWallet = AccountData;
+export type SeiWallet = DirectSecp256k1HdWallet;
 
 export type SolanaWallet = {
   conn: solana.Connection;

--- a/relayer/middleware/wallet/walletToolBox.ts
+++ b/relayer/middleware/wallet/walletToolBox.ts
@@ -113,7 +113,7 @@ async function createSeiWalletToolBox(
 
   return {
     ...providers,
-    wallet: seiAccount,
+    wallet: seiWallet,
     address: seiAccount.address,
     async getBalance(): Promise<string> {
       const b = await seiProvider.getBalance(seiAccount.address, "usei");


### PR DESCRIPTION
We need access to `DirectSecp256k1HdWallet` instead of the `AccountData` so that in the `onSei` handler, the user can create a `signingCosmWasmClient`.