### PR TITLE
fix missedvaa prefix + limit  concurrency to crawl missing vaas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@sei-js/core": "^1.3.4",
         "@xlabs-xyz/wallet-monitor": "0.1.16",
         "bech32": "^2.0.0",
+        "bluebird": "^3.7.2",
         "bullmq": "^3.10.1",
         "ethers": "^5.7.2",
         "generic-pool": "^3.9.0",
@@ -29,6 +30,8 @@
         "winston": "^3.8.2"
       },
       "devDependencies": {
+        "@jest/globals": "^29.5.0",
+        "@types/bluebird": "^3.5.38",
         "@types/bs58": "^4.0.1",
         "@types/jest": "^29.5.1",
         "@types/koa": "^2.13.5",
@@ -2373,8 +2376,9 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
+      "integrity": "sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
         "@jest/expect": "^29.5.0",
@@ -3978,6 +3982,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
+    },
     "node_modules/@types/bn.js": {
       "version": "5.1.1",
       "license": "MIT",
@@ -4816,7 +4826,8 @@
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -12366,6 +12377,8 @@
     },
     "@jest/globals": {
       "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
+      "integrity": "sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==",
       "dev": true,
       "requires": {
         "@jest/environment": "^29.5.0",
@@ -13711,6 +13724,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
+    },
     "@types/bn.js": {
       "version": "5.1.1",
       "requires": {
@@ -14335,7 +14354,9 @@
       "version": "1.2.1"
     },
     "bluebird": {
-      "version": "3.7.2"
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
       "version": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@sei-js/core": "^1.3.4",
     "@xlabs-xyz/wallet-monitor": "0.1.16",
     "bech32": "^2.0.0",
+    "bluebird": "^3.7.2",
     "bullmq": "^3.10.1",
     "ethers": "^5.7.2",
     "generic-pool": "^3.9.0",
@@ -41,6 +42,8 @@
   },
   "keywords": [],
   "devDependencies": {
+    "@jest/globals": "^29.5.0",
+    "@types/bluebird": "^3.5.38",
     "@types/bs58": "^4.0.1",
     "@types/jest": "^29.5.1",
     "@types/koa": "^2.13.5",

--- a/relayer/middleware/missedVaas/missedVaas.middleware.ts
+++ b/relayer/middleware/missedVaas/missedVaas.middleware.ts
@@ -134,7 +134,7 @@ export async function missedVaaJob(
 ) {
   try {
     logger?.debug(`Checking for missed VAAs.`);
-    
+
     const addressWithSeenSeqs = await mapCocurrent(filters, async filter => {
       const address = {
         emitterChain: filter.emitterFilter.chainId,
@@ -193,11 +193,15 @@ export async function missedVaaJob(
       }
 
       if (missing.length > 0) {
-        logger?.info(`missedVaaWorker found ${missing.length} missed vaas ${JSON.stringify({
-          emitterAddress,
-          emitterChain,
-          missedSequences: missing,
-        })}`);
+        logger?.info(
+          `missedVaaWorker found ${missing.length} missed vaas ${JSON.stringify(
+            {
+              emitterAddress,
+              emitterChain,
+              missedSequences: missing,
+            },
+          )}`,
+        );
       }
     }
   } catch (e) {

--- a/relayer/middleware/missedVaas/missedVaas.middleware.ts
+++ b/relayer/middleware/missedVaas/missedVaas.middleware.ts
@@ -11,7 +11,7 @@ import {
 } from "../../application";
 import { Logger } from "winston";
 import { createPool, Pool } from "generic-pool";
-import { minute, sleep } from "../../utils";
+import { mapCocurrent, minute, sleep } from "../../utils";
 import { RedisConnectionOpts } from "../../storage/redis-storage";
 import { GetSignedVAAResponse } from "@certusone/wormhole-sdk-proto-web/lib/cjs/publicrpc/v1/publicrpc";
 
@@ -134,21 +134,20 @@ export async function missedVaaJob(
 ) {
   try {
     logger?.debug(`Checking for missed VAAs.`);
-    let addressWithSeenSeqs = await Promise.all(
-      filters
-        .map(filter => ({
-          emitterChain: filter.emitterFilter.chainId,
-          emitterAddress: filter.emitterFilter.emitterAddress,
-        }))
-        .map(async address => {
-          const seenSeqs = await getAllProcessedSeqsInOrder(
-            redis,
-            address.emitterChain,
-            address.emitterAddress,
-          );
-          return { address, seenSeqs };
-        }),
-    );
+    
+    const addressWithSeenSeqs = await mapCocurrent(filters, async filter => {
+      const address = {
+        emitterChain: filter.emitterFilter.chainId,
+        emitterAddress: filter.emitterFilter.emitterAddress,
+      };
+
+      const seenSeqs = await getAllProcessedSeqsInOrder(
+        redis,
+        address.emitterChain,
+        address.emitterAddress,
+      );
+      return { address, seenSeqs };
+    });
 
     for (const {
       address: { emitterAddress, emitterChain },
@@ -194,11 +193,11 @@ export async function missedVaaJob(
       }
 
       if (missing.length > 0) {
-        logger?.info(`missedVaaWorker found ${missing.length} missed vaas`, {
+        logger?.info(`missedVaaWorker found ${missing.length} missed vaas ${JSON.stringify({
           emitterAddress,
           emitterChain,
           missedSequences: missing,
-        });
+        })}`);
       }
     }
   } catch (e) {
@@ -305,7 +304,7 @@ export async function markProcessed(
 }
 
 function getKey(emitterChain: number, emitterAddress: string): string {
-  return `missedVaas:${emitterChain}:${emitterAddress}`;
+  return `missedVaasV2:${emitterChain}:${emitterAddress}`;
 }
 
 function getInProgressKey({

--- a/relayer/middleware/missedVaas/missedVaas.middleware.ts
+++ b/relayer/middleware/missedVaas/missedVaas.middleware.ts
@@ -11,7 +11,7 @@ import {
 } from "../../application";
 import { Logger } from "winston";
 import { createPool, Pool } from "generic-pool";
-import { mapCocurrent, minute, sleep } from "../../utils";
+import { mapConcurrent, minute, sleep } from "../../utils";
 import { RedisConnectionOpts } from "../../storage/redis-storage";
 import { GetSignedVAAResponse } from "@certusone/wormhole-sdk-proto-web/lib/cjs/publicrpc/v1/publicrpc";
 
@@ -135,7 +135,7 @@ export async function missedVaaJob(
   try {
     logger?.debug(`Checking for missed VAAs.`);
 
-    const addressWithSeenSeqs = await mapCocurrent(filters, async filter => {
+    const addressWithSeenSeqs = await mapConcurrent(filters, async filter => {
       const address = {
         emitterChain: filter.emitterFilter.chainId,
         emitterAddress: filter.emitterFilter.emitterAddress,

--- a/relayer/utils.ts
+++ b/relayer/utils.ts
@@ -12,6 +12,7 @@ import {
 } from "@certusone/wormhole-sdk";
 import { ParsedVaaWithBytes } from "./application";
 import { ethers } from "ethers";
+import { map } from 'bluebird';
 
 export function encodeEmitterAddress(
   chainId: wormholeSdk.ChainId,
@@ -190,3 +191,7 @@ export function dbg<T>(x: T, msg?: string): T {
   console.log(x);
   return x;
 }
+
+export function mapCocurrent(arr: any[], fn: (...args: any[]) => any, concurrency: number = 5) {
+  return map(arr, fn, { concurrency });
+};

--- a/relayer/utils.ts
+++ b/relayer/utils.ts
@@ -12,7 +12,7 @@ import {
 } from "@certusone/wormhole-sdk";
 import { ParsedVaaWithBytes } from "./application";
 import { ethers } from "ethers";
-import { map } from 'bluebird';
+import { map } from "bluebird";
 
 export function encodeEmitterAddress(
   chainId: wormholeSdk.ChainId,
@@ -192,6 +192,10 @@ export function dbg<T>(x: T, msg?: string): T {
   return x;
 }
 
-export function mapCocurrent(arr: any[], fn: (...args: any[]) => any, concurrency: number = 5) {
+export function mapCocurrent(
+  arr: any[],
+  fn: (...args: any[]) => any,
+  concurrency: number = 5,
+) {
   return map(arr, fn, { concurrency });
-};
+}

--- a/relayer/utils.ts
+++ b/relayer/utils.ts
@@ -192,7 +192,7 @@ export function dbg<T>(x: T, msg?: string): T {
   return x;
 }
 
-export function mapCocurrent(
+export function mapConcurrent(
   arr: any[],
   fn: (...args: any[]) => any,
   concurrency: number = 5,


### PR DESCRIPTION
New missedVaa implementation is throwing an error after been deployed.
The error is caused because the new implementation uses a new data-type to store the "seen" vaas, but the key used remains the same, which is causing a conflict when the missed VAA worker tries to fetch the "seen" vaas (it asks for a sorted set, but in redis there is a regular set for that key, which triggers an error at redis engine level).
Another possible solution would be to remove the prefix from redis at the moment of the deploy, but that would be something that any current user of the relayer engine would have to do, so it's not that easy to pull.

I've also added concurrency control to the missed vaa worker to avoid overloading redis with many concurrent queries