### PR TITLE
Adds listener for skipped vaas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/bs58": "^4.0.1",
         "@types/jest": "^29.5.1",
         "@types/koa": "^2.13.5",
+        "@types/node": "^20.3.1",
         "@types/winston": "^2.4.4",
         "jest": "^29.5.0",
         "prettier": "^2.8.4",
@@ -656,6 +657,11 @@
         "@types/long": "^4.0.2",
         "@types/node": "^18.0.3"
       }
+    },
+    "node_modules/@certusone/wormhole-sdk-wasm/node_modules/@types/node": {
+      "version": "18.16.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+      "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw=="
     },
     "node_modules/@certusone/wormhole-spydk": {
       "version": "0.0.1",
@@ -4193,8 +4199,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.13.0",
-      "license": "MIT"
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
     "node_modules/@types/object-hash": {
       "version": "1.3.4",
@@ -11442,6 +11449,13 @@
       "requires": {
         "@types/long": "^4.0.2",
         "@types/node": "^18.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.16.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+          "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw=="
+        }
       }
     },
     "@certusone/wormhole-spydk": {
@@ -14215,7 +14229,9 @@
       "devOptional": true
     },
     "@types/node": {
-      "version": "18.13.0"
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
     "@types/object-hash": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/bs58": "^4.0.1",
     "@types/jest": "^29.5.1",
     "@types/koa": "^2.13.5",
+    "@types/node": "^20.3.1",
     "@types/winston": "^2.4.4",
     "jest": "^29.5.0",
     "prettier": "^2.8.4",

--- a/relayer/middleware/missedVaas/missedVaas.middleware.ts
+++ b/relayer/middleware/missedVaas/missedVaas.middleware.ts
@@ -62,7 +62,7 @@ export function missedVaas(
   const redisPool = createRedisPool(opts);
 
   // mark vaa processed when app emits "Added" event
-  app.addListener(RelayerEvents.Added, (vaa: ParsedVaaWithBytes) => {
+  const markVaaAsProcessed = (vaa: ParsedVaaWithBytes) => {
     redisPool.use(redis =>
       markProcessed(
         redis,
@@ -74,7 +74,10 @@ export function missedVaas(
         opts.logger,
       ),
     );
-  });
+  };
+
+  app.addListener(RelayerEvents.Added, markVaaAsProcessed);
+  app.addListener(RelayerEvents.Skipped, markVaaAsProcessed);
 
   // construct dependency
   const fetchVaaFn = (vaaKey: VaaKey) => fetchVaa(opts.wormholeRpcs, vaaKey);

--- a/relayer/middleware/wallet/wallet-management.ts
+++ b/relayer/middleware/wallet/wallet-management.ts
@@ -137,6 +137,7 @@ export function startWalletManagement(
   const manager = buildWalletManager({
     config: wallets,
     options: {
+      failOnInvalidChain: false,
       logger: logger?.child({ module: "wallet-manager" }),
       logLevel: "error",
       metrics: metricsOpts,


### PR DESCRIPTION
TODO: the spy pushes the same vaa multiple times (a consequence of its stateless nature coupled with a p2p network natural behavior). We shouldn't hit redis needlessly if we've already seen a vaa.