### PR TITLE
Docs: reformat readme to be more like a tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,37 @@
 # Relayer Engine
 
-Specify how to relay wormhole messages for your app using an idiomatic an express/koa middleware inspired api and let the library handle all the details!
+The Relayer Engine is a package meant to provide the structure and a starting point for a custom relayer.
 
-Checkout the [example app](./example-app) or check out the [quickstart](#quick-start)
+With the Relayer Engine, a developer can write specific logic for filtering to receive only the messages they care about.
 
-## Quick Start
+Once a wormhole message is received, the developer may apply additional logic to parse custom payloads or submit the VAA to one or many destination chains.
 
-`npm i wormhole-foundation/relayer-engine`
+To use the Relayer engine, a developer may specify how to relay wormhole messages for their app using an idiomatic express/koa middleware inspired api then let the library handle all the details!
 
-`yarn add wormhole-foundation/relayer-engine`
+Checkout the full [example app](https://github.com/wormhole-foundation/relayer-engine/tree/main/example-app) or follow the instructions in the [quickstart](#quick-start)
 
-### Minimal code necessary to get started
+# Quick Start
 
-```typescript
-import {
-  Environment,
-  StandardRelayerApp,
-  StandardRelayerContext,
-} from "@wormhole-foundation/relayer-engine";
+## Install Package
 
-import { CHAIN_ID_SOLANA } from "@certusone/wormhole-sdk";
+First, install the relayer engine package with `npm` or `yarn`
 
-(async function main() {
-  const app = new StandardRelayerApp<StandardRelayerContext>(
-    Environment.MAINNET,
-    {
-      // other app specific config options can be set here for things
-      // like retries, logger, or redis connection settings.
-      name: "ExampleRelayer",
-    },
-  );
-
-  app.chain(CHAIN_ID_SOLANA).address(
-    // emitter address on Solana
-    "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe",
-    // callback function to invoke on new message
-    async (ctx, next) => {
-      const vaa = ctx.vaa;
-      const hash = ctx.sourceTxHash;
-    },
-  );
-
-  app.listen();
-})();
+```sh
+npm i @wormhole-foundation/relayer-engine
 ```
 
-### Minimal Processes to track the VAAs
+## Start Background Processes
 
-:memo: These proceses must be running in order for the code above to work
+> note: These processes _must_ be running in order for the relayer app below to work
 
-**Wormhole Network Spy**
+Next, we must start a Spy to listen for available VAAs published on the guardian network as well as a persistence layer, in this case we're using Redis.
 
-In order for the Relayer app created above to receive messages, a local Spy must be running that watches the guardian network.
+### Wormhole Network Spy
 
-For testnet:
+In order for our Relayer app to receive messages, a local Spy must be running that watches the guardian network. Our relayer app will receive updates from this Spy.
+
+<details>
+<summary><b>Testnet Spy</b></summary>
 
 ```bash
 docker run --platform=linux/amd64 \
@@ -66,7 +44,10 @@ spy \
 --bootstrap /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWAkB9ynDur1Jtoa97LBUp8RXdhzS5uHgAfdTquJbrbN7i
 ```
 
-For mainnet:
+</details>
+
+<details>
+<summary><b>Mainnet Spy</b></summary>
 
 ```bash
 docker run --platform=linux/amd64 \
@@ -79,7 +60,9 @@ spy \
 --bootstrap /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7
 ```
 
-**Run redis**
+</details>
+
+### Redis Persistence
 
 A Redis instance must also be available to persist job data for fetching VAAs from the Spy.
 
@@ -87,19 +70,51 @@ A Redis instance must also be available to persist job data for fetching VAAs fr
 docker run --rm -p 6379:6379 --name redis-docker -d redis
 ```
 
-## Objective
+> Note: While we're using Redis here, the persistence layer can be swapped out for some other db by implementing the appropriate [interface](https://github.com/wormhole-foundation/relayer-engine/blob/main/relayer/storage/redis-storage.ts).
 
-Make it easy to write the off-chain component of a wormhole cross-chain app (aka [xDapp](https://book.wormhole.com/dapps/4_whatIsanXdapp.html)).
+## Simple Relayer Code Example
 
-An xDapp developer can write their app specific logic for filtering what wormhole messages they care about, how to parse custom payloads and what actions to take on chain (or across many chains!).
+In the following example, we'll:
 
-The Goal is to create a project that is:
+1. Set up a StandardRelayerApp, passing configuration options for our Relayer
+2. Add a filter to capture only those messages our app cares about with a callback to do _something_ with the VAA once we've gotten it
+3. Start the Relayer app
 
-- Immediately intuitive
-- Idiomatic
-- Minimal footprint
-- Composable
-- Easily extensible
-- Good separation of concerns
-- Reliable
-- Convention over configuration
+```ts
+import {
+  Environment,
+  StandardRelayerApp,
+  StandardRelayerContext,
+} from "@wormhole-foundation/relayer-engine";
+import { CHAIN_ID_SOLANA } from "@certusone/wormhole-sdk";
+
+(async function main() {
+  // initialize relayer engine app, pass relevant config options
+  const app = new StandardRelayerApp<StandardRelayerContext>(
+    Environment.TESTNET,
+    {
+      // other app specific config options can be set here for things
+      // like retries, logger, or redis connection settings.
+      name: "ExampleRelayer",
+    },
+  );
+
+  // add a filter with a callback that will be
+  // invoked on finding a VAA that matches the filter
+  app.chain(CHAIN_ID_SOLANA).address(
+    // emitter address on Solana
+    "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe",
+    // callback function to invoke on new message
+    async (ctx, next) => {
+      const vaa = ctx.vaa;
+      const hash = ctx.sourceTxHash;
+      console.log(
+        `Got a VAA with sequence: ${vaa.sequence} from with txhash: ${hash}`,
+      );
+    },
+  );
+
+  // start app, blocks until unrecoverable error or process is stopped
+  await app.listen();
+})();
+```

--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ This will run until the process is killed or it encounters an unrecoverable erro
 
 ## Advanced Example
 
-For a more advanced example that details other middleware and more complex configuration and actions including a built in UI, see the [Advanced Tutorial](./example-app/README.md)
+For a more advanced example that details other middleware and more complex configuration and actions including a built in UI, see the [Advanced Tutorial](./advanced-example.md)

--- a/README.md
+++ b/README.md
@@ -155,21 +155,21 @@ Other options for the `StandardRelayerAppOpts` include:
   redis?: RedisOptions;
 ```
 
-The next meaningful line in the example adds a filter middleware component. This middleware will cause the Relayer app to request a subscription from the Spy for any VAAs that match the criteria and invoke the callback with the VAA. 
+The next meaningful line in the example adds a filter middleware component. This middleware will cause the Relayer app to request a subscription from the Spy for any VAAs that match the criteria and invoke the callback with the VAA.
 
 If you'd like your program to subscribe to multiple chains and addresses, the same method can be called several times or the `multiple` helper can be used.
 
 ```ts
 app.multiple(
-  { 
+  {
     [CHAIN_ID_SOLANA]: "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe"
     [CHAIN_ID_ETH]: ["0xabc1230000000...","0xdef456000....."]
-  }, 
-  myCallback 
+  },
+  myCallback
 );
 ```
 
-The last line in the simple example runs `await app.listen()`, which will start the relayer engine. Once started, the relayer engine will issue subscription requests to the spy and begin any other workflows (e.g. tracking missed VAAs).  
+The last line in the simple example runs `await app.listen()`, which will start the relayer engine. Once started, the relayer engine will issue subscription requests to the spy and begin any other workflows (e.g. tracking missed VAAs).
 
 This will run until the process is killed or it encounters an unrecoverable error. If you'd like to shut down the relayer gracefully, call `app.stop()`.
 

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -1,0 +1,41 @@
+# Example Relayer Engine Application
+
+This example details a more complex implementation of a Relayer Application. For a simple example see this [example](../README.md#simple-relayer-code-example)
+
+
+## Setup 
+
+> note: In order to run the Spy and Redis for this tutorial, you must have `docker` installed
+
+
+### Get the code
+
+Clone the repository, `cd` into the directory, and install the requirements.
+
+```sh
+git clone https://github.com/wormhole-foundation/relayer-engine.git
+cd relayer-engine/example-app
+npm i
+```
+
+### Start the background services
+
+
+Start the Spy to subscribe to gossiped messages on the Guardian network.
+
+```sh
+npm run testnet-spy
+```
+
+In another CLI window, start Redis.
+
+```sh
+npm run redis
+```
+
+### Start the relayer
+
+```sh
+npm run start
+```
+

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -2,11 +2,9 @@
 
 This example details a more complex implementation of a Relayer Application. For a simple example see this [example](../README.md#simple-relayer-code-example)
 
+## Setup
 
-## Setup 
-
-> note: In order to run the Spy and Redis for this tutorial, you must have `docker` installed
-
+> note: In order to run the Spy and Redis for this tutorial, you must have `docker` installed.
 
 ### Get the code
 
@@ -18,8 +16,9 @@ cd relayer-engine/example-app
 npm i
 ```
 
-### Start the background services
+## Run it
 
+### Start the background services
 
 Start the Spy to subscribe to gossiped messages on the Guardian network.
 
@@ -27,7 +26,7 @@ Start the Spy to subscribe to gossiped messages on the Guardian network.
 npm run testnet-spy
 ```
 
-In another CLI window, start Redis.
+In another CLI window, start Redis. For this application, Redis is used as the persistence layer to keep track of VAAs we've seen.
 
 ```sh
 npm run redis
@@ -35,7 +34,160 @@ npm run redis
 
 ### Start the relayer
 
+Once the background processes are running, we can start the relayer. This will subscribe to relevant messages from the Spy and track VAAs, taking some action when one is received.
+
 ```sh
 npm run start
 ```
 
+## Code Walkthrough
+
+The source for this example is available [here](https://github.com/wormhole-foundation/relayer-engine/blob/main/example-app/src/app.ts)
+
+### Context
+
+The first meaningful line is a Type declaration for the `Context` we want to provide our Relayer app.
+
+```ts
+export type MyRelayerContext = LoggingContext &
+  StorageContext &
+  SourceTxContext &
+  TokenBridgeContext &
+  StagingAreaContext &
+  WalletContext;
+```
+
+This type, which we later use to parameterize the generic `RelayerApp`, specifies the union of `Context` objects that are available to the `RelayerApp`.
+
+Because the `Context` object is passed to the callback for processors, providing a type parameterized type definition ensures the appropriate fields are available within the callback on the `Context` object.
+
+<!-- TODO: private keys -->
+
+### App Creation
+
+Next we instantiate a `RelayerApp`, passing our `Context` type to parameterize it.
+
+```ts
+const app = new RelayerApp<MyRelayerContext>(Environment.TESTNET);
+```
+
+For this example we've defined a class, `ApiController`, to provide methods we'll pass to our processor callbacks. Note that the `ctx` argument type matches the `Context` type we defined.
+
+```ts
+export class ApiController {
+  processFundsTransfer = async (ctx: MyRelayerContext, next: Next) => {
+    // ...
+  };
+}
+```
+
+This is not required but a pattern like this helps organize the codebase as the `RelayerApp` grows.
+
+We instantiate our controller class and begin to configure our application by passing the Spy URL, storage layer, and logger.
+
+```ts
+const fundsCtrl = new ApiController();
+const namespace = "simple-relayer-example";
+const store = new RedisStorage({
+  attempts: 3,
+  namespace, // used for redis key namespace
+  queueName: "relays",
+});
+
+// ...
+
+app.spy("localhost:7073");
+app.useStorage(store);
+app.logger(rootLogger);
+```
+
+### Middleware
+
+With our app configured, we can begin to add `Middleware`.
+
+`Middleware` is the term for the functional components we wish to apply to each VAA received.
+
+The `RelayerApp` defines a `use` method which accepts one or more `Middleware` instances, also parameterized with a `Context` type.
+
+```ts
+use(...middleware: Middleware<ContextT>[] | ErrorMiddleware<ContextT>[])
+```
+
+By passing the `use` method an instance of some `Middleware`, we add it to the pipeline of handlers invoked by the `RelayerApp`.
+
+> Note that the order the `Middleware` is added here matters since a VAA is passed through each in the same order.
+
+```ts
+// we want an instance of a logger available on the context
+app.use(logging(rootLogger));
+// we want to check for any missed VAAs if we receive out of order sequence ids
+app.use(missedVaas(app, { namespace: "simple", logger: rootLogger }));
+// we want to apply the chain specific providers to the context passed downstream
+app.use(providers());
+
+// make wallets available within the context
+app.use(
+  wallets(Environment.TESTNET, {
+    privateKeys,
+    namespace,
+    metrics: { enabled: true, registry: store.registry },
+  })
+);
+
+// enrich the context with details about the token bridge
+app.use(tokenBridgeContracts());
+app.use(stagingArea());
+// make sure we have the source tx hash
+app.use(sourceTx());
+```
+
+### Subscriptions
+
+With our `Middleware` setup, we can configure a subscription to receive only the VAAs we care about.
+
+Here we set up a subscription request to receive VAAs that originated from Solana and were emitted by the address `DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe`.
+
+On receipt of a VAA that matches this filter, the `fundsCtrl.processFundsTransfer` callback is invoked with an instance of the `Context` object that has already been passed through the `Middleware` we set up before.
+
+```ts
+app
+  .chain(CHAIN_ID_SOLANA)
+  .address(
+    "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe",
+    fundsCtrl.processFundsTransfer
+  );
+```
+
+To subscribe to more chains or addresses, this pattern can be repeated or the `multiple` method can be called with an object of `ChainId` to `Address`
+
+```ts
+app.multiple(
+  {
+    [CHAIN_ID_SOLANA]: "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe"
+    [CHAIN_ID_ETH]: ["0xabc1230000000...","0xdef456000....."]
+  },
+  fundsCtrl.processFundsTransfer
+);
+```
+
+<!-- TODO: error handler -->
+
+### Start listening
+
+Finally, calling `app.listen()` will start the `RelayerApp`, issuing subscription requests and handling VAAs as we've configured it.
+
+The `listen` method is async and `await`-ing it will block until the program dies from an unrecoverable error, the process is killed, or the app is stopped with `app.stop()`.
+
+### Bonus UI
+
+For this example, we've provided a default UI using `koa`.
+
+When the program is running, you may open a browser to `http://localhost:3000/ui` to see details about the running application.
+
+## Going further
+
+The included default functionality may be insufficient for your use case.
+
+If you'd like to apply some specific intermediate processing steps, consider implementing some custom `Middleware`. Be sure to include the appropriate `Context` in the `RelayerApp` type parameterization for any fields you wish to have added to the `Context` object passed to downstream `Middleware`.
+
+If you'd prefer a storage layer besides redis, simply implement the (storage)[https://github.com/wormhole-foundation/relayer-engine/blob/main/relayer/storage/storage.ts] interface.

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -27,18 +27,21 @@
       }
     },
     "..": {
+      "name": "@wormhole-foundation/relayer-engine",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bull-board/api": "^5.0.0",
         "@bull-board/koa": "^5.0.0",
-        "@certusone/wormhole-sdk": "^0.9.16",
+        "@certusone/wormhole-sdk": "^0.9.17",
         "@certusone/wormhole-spydk": "^0.0.1",
         "@datastructures-js/queue": "^4.2.3",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@mysten/sui.js": "^0.32.2",
-        "@xlabs-xyz/wallet-monitor": "0.1.9",
+        "@sei-js/core": "^1.3.4",
+        "@xlabs-xyz/wallet-monitor": "0.2.5",
         "bech32": "^2.0.0",
+        "bluebird": "^3.7.2",
         "bullmq": "^3.10.1",
         "ethers": "^5.7.2",
         "generic-pool": "^3.9.0",
@@ -46,14 +49,20 @@
         "koa": "^2.14.1",
         "lru-cache": "^9.1.1",
         "prom-client": "^14.2.0",
-        "typescript": "^4.9.5",
         "winston": "^3.8.2"
       },
       "devDependencies": {
+        "@jest/globals": "^29.5.0",
+        "@types/bluebird": "^3.5.38",
         "@types/bs58": "^4.0.1",
+        "@types/jest": "^29.5.1",
         "@types/koa": "^2.13.5",
+        "@types/node": "^20.3.1",
         "@types/winston": "^2.4.4",
-        "prettier": "^2.8.4"
+        "jest": "^29.5.0",
+        "prettier": "^2.8.4",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@apollo/client": {
@@ -3652,6 +3661,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -4009,6 +4019,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -6,7 +6,9 @@
     "start": "ts-node src/app.ts",
     "build": "tsc",
     "watch": "tsc --watch",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "redis": "docker run --rm -p 6379:6379 --name redis-docker -d redis",
+    "mainnet-spy": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/mainnet/2 --bootstrap /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7",
+    "testnet-spy": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/testnet/2/1 --bootstrap /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWAkB9ynDur1Jtoa97LBUp8RXdhzS5uHgAfdTquJbrbN7i"
   },
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.11",

--- a/example-app/src/app.ts
+++ b/example-app/src/app.ts
@@ -71,8 +71,8 @@ const privateKeys = {
 async function main() {
   let opts: any = yargs(process.argv.slice(2)).argv;
 
-  const env = Environment.TESTNET;
-  const app = new RelayerApp<MyRelayerContext>(env);
+  const app = new RelayerApp<MyRelayerContext>(Environment.TESTNET);
+
   const fundsCtrl = new ApiController();
   const namespace = "simple-relayer-example";
   // Config
@@ -107,7 +107,7 @@ async function main() {
       fundsCtrl.processFundsTransfer
     );
 
-  // Another way to do it if you want to listen to multiple addresses on different chaints:
+  // Another way to do it if you want to listen to multiple addresses on different chains:
   // app.multiple(
   //   { [CHAIN_ID_SOLANA]: "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe"
   //     [CHAIN_ID_ETH]: ["0xabc1230000000...","0xdef456000....."]


### PR DESCRIPTION
I'd like to use these markdown files directly in the docs, so the readme is wordsmithed a bit and a there is a new markdown file to explain the `example-app`.

------

Is anything missing?

Notably there is no detail on what to do inside the callback once a VAA is received. Almost always a dev would want to see some example of how the VAA is actually relayed/redeemed, not just fetched and persisted.

Should I wait on the `connect-sdk` to be released or try to write something using the existing SDK?