### PR TITLE
relayer: improves error messages in source tx middleware.

### DIFF
--- a/relayer/middleware/source-tx.middleware.ts
+++ b/relayer/middleware/source-tx.middleware.ts
@@ -88,16 +88,15 @@ export async function fetchVaaHash(
       );
       if (res.status === 404) {
         throw new Error("Not found yet.");
-      } else if (!res.ok) {
-        throw new Error(
-          `Unexpected HTTP response. Status: ${
-            res.status
-          } Response: ${await res.text()}`,
-        );
       }
-      // TODO: consider restricting this code path further to just status 200 and a few others.
+
       // Note that we're assuming the response is UTF8 encoded here.
       body = await res.text();
+      if (!res.ok) {
+        throw new Error(`Unexpected HTTP response. Status: ${res.status}`);
+      }
+
+      // TODO: consider restricting this code path further to just status 200 and a few others.
       txHash = JSON.parse(body).data?.txHash;
     } catch (error) {
       const httpBodyText =

--- a/relayer/middleware/source-tx.middleware.ts
+++ b/relayer/middleware/source-tx.middleware.ts
@@ -59,7 +59,7 @@ export function sourceTx(
     );
     ctx.logger?.debug(
       txHash === ""
-        ? "Could not retrive tx hash."
+        ? "Could not retrieve tx hash."
         : `Retrieved tx hash: ${txHash}`,
     );
     ctx.sourceTxHash = txHash;
@@ -79,6 +79,7 @@ export async function fetchVaaHash(
   let attempt = 0;
   let txHash = "";
   do {
+    let body;
     try {
       const res = await fetch(
         `${baseEndpoint}/api/v1/vaas/${emitterChain}/${emitterAddress.toString(
@@ -87,15 +88,23 @@ export async function fetchVaaHash(
       );
       if (res.status === 404) {
         throw new Error("Not found yet.");
-      } else if (res.status > 500) {
-        throw new Error(`Got: ${res.status}`);
+      } else if (!res.ok) {
+        throw new Error(
+          `Unexpected HTTP response. Status: ${
+            res.status
+          } Response: ${await res.text()}`,
+        );
       }
-      txHash = (await res.json()).data?.txHash;
-    } catch (e) {
-      logger?.error(
-        `could not obtain txHash, attempt: ${attempt} of ${retries}.`,
-        e,
-      );
+      // TODO: consider restricting this code path further to just status 200 and a few others.
+      // Note that we're assuming the response is UTF8 encoded here.
+      body = await res.text();
+      txHash = JSON.parse(body).data?.txHash;
+    } catch (error) {
+      const httpBodyText =
+        body !== undefined ? `\nHTTP response body: ${body}` : "";
+      const errorMessage = `could not obtain txHash, attempt: ${attempt} of ${retries}.${httpBodyText}
+Error: ${error}`;
+      logger?.error(errorMessage);
       await sleep((attempt + 1) * 200); // linear wait
     }
   } while (++attempt < retries && !txHash);


### PR DESCRIPTION
In the fetch function:
- Adds HTTP body response to some errors if present (still assumes it is UTF8 encoded)
- Throws error on anything outside the 200-299 HTTP response status range.