### PR TITLE
Hotfix/minor metrics improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@mysten/sui.js": "^0.32.2",
         "@sei-js/core": "^1.3.4",
-        "@xlabs-xyz/wallet-monitor": "0.2.5",
+        "@xlabs-xyz/wallet-monitor": "^0.2.8",
         "bech32": "^2.0.0",
         "bluebird": "^3.7.2",
         "bullmq": "^3.10.1",
@@ -4317,9 +4317,9 @@
       }
     },
     "node_modules/@xlabs-xyz/wallet-monitor": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@xlabs-xyz/wallet-monitor/-/wallet-monitor-0.2.5.tgz",
-      "integrity": "sha512-z8kgoBspo29LDPa411ous5tQdmyIU7KUfiSTqE/wZ9cWkYpiTWLZ9x5irOdSDJdm1Zz0vavgeYRzrjukzoVD/A==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@xlabs-xyz/wallet-monitor/-/wallet-monitor-0.2.8.tgz",
+      "integrity": "sha512-eVTFtowN6nZ3l1dv/CdgaBB6JjJdNCbgJEmjM71Bll7HzuROvA2pkrf4tD/0bG0IilQEZdvkeTFeN5oP6jf5YQ==",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@mysten/sui.js": "^0.32.2",
@@ -14326,9 +14326,9 @@
       }
     },
     "@xlabs-xyz/wallet-monitor": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@xlabs-xyz/wallet-monitor/-/wallet-monitor-0.2.5.tgz",
-      "integrity": "sha512-z8kgoBspo29LDPa411ous5tQdmyIU7KUfiSTqE/wZ9cWkYpiTWLZ9x5irOdSDJdm1Zz0vavgeYRzrjukzoVD/A==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@xlabs-xyz/wallet-monitor/-/wallet-monitor-0.2.8.tgz",
+      "integrity": "sha512-eVTFtowN6nZ3l1dv/CdgaBB6JjJdNCbgJEmjM71Bll7HzuROvA2pkrf4tD/0bG0IilQEZdvkeTFeN5oP6jf5YQ==",
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@mysten/sui.js": "^0.32.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@mysten/sui.js": "^0.32.2",
     "@sei-js/core": "^1.3.4",
-    "@xlabs-xyz/wallet-monitor": "0.2.5",
+    "@xlabs-xyz/wallet-monitor": "^0.2.8",
     "bech32": "^2.0.0",
     "bluebird": "^3.7.2",
     "bullmq": "^3.10.1",

--- a/relayer/storage.metrics.ts
+++ b/relayer/storage.metrics.ts
@@ -69,7 +69,9 @@ export function createStorageMetrics(
       completedDuration: new Histogram({
         name: `workflow_total_duration`,
         help: "Completion time in ms for jobs (created until completed)",
-        buckets: [7500, 10000, 20000, 30000, 45000, 60000, 90000, 120000, 240000],
+        buckets: [
+          7500, 10000, 20000, 30000, 45000, 60000, 90000, 120000, 240000,
+        ],
         labelNames: ["queue"],
         registers: [storageRegistry],
       }),

--- a/relayer/storage.metrics.ts
+++ b/relayer/storage.metrics.ts
@@ -62,14 +62,14 @@ export function createStorageMetrics(
       processedDuration: new Histogram({
         name: `worklow_processing_duration`,
         help: "Processing time in ms for completed jobs (processing until completed)",
-        buckets: [100, 500, 1000, 2500, 5000, 7500, 10000, 25000],
+        buckets: [6000, 7000, 7500, 8000, 8500, 9000, 10000, 12000],
         labelNames: ["queue"],
         registers: [storageRegistry],
       }),
       completedDuration: new Histogram({
         name: `workflow_total_duration`,
         help: "Completion time in ms for jobs (created until completed)",
-        buckets: [500, 1000, 2500, 5000, 7500, 10000, 25000, 50000, 100000],
+        buckets: [7500, 10000, 20000, 30000, 45000, 60000, 90000, 120000, 240000],
         labelNames: ["queue"],
         registers: [storageRegistry],
       }),


### PR DESCRIPTION
- update workflow_duration buckets so that they resemble more closely the actual duration of a workflow. This should be something that can be configured during RE instantiation. I'll try to address this soon
- Updates wallet-monitor version to 0.2.8 to add support for Klatyn and Optimism chains