### PR TITLE
Use prepack instead of prepare for yarn compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "prettier --write .",
     "mainnet-spy": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/mainnet/2 --bootstrap /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7",
     "testnet-spy": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/testnet/2/1 --bootstrap /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWAkB9ynDur1Jtoa97LBUp8RXdhzS5uHgAfdTquJbrbN7i",
-    "prepare": "npm run build"
+    "prepack": "npm run build"
   },
   "author": "Joe Howarth",
   "license": "Apache-2.0",


### PR DESCRIPTION
both prepare and prepack run after installing from a gitrepository AND before packing a tarball for publishing. This means we can run typescript -> js compilation here.