### PR TITLE
Hotfix: provider middleware

### DIFF
--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -177,11 +177,12 @@ export function providers(opts?: ProvidersOpts): Middleware<ProviderContext> {
       );
 
       logger?.debug(`Providers initializing... ${JSON.stringify(supportedChains)}`);
-      providers = await buildProviders(supportedChains);
-      logger?.debug(`Providers Initialized: ${JSON.stringify(providers)}`);
+      providers = await buildProviders(supportedChains, logger);
+      logger?.debug(`Providers Initialized succesfully.`);
     }
+
     ctx.providers = providers;
-    ctx.logger?.debug("Providers attached to context");
+    
     await next();
   };
 }

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -58,7 +58,6 @@ export type ChainConfigInfo = {
 
 export interface ProvidersOpts {
   chains: Partial<ChainConfigInfo>;
-  supportedChains?: string[];
 }
 
 const defaultSupportedChains = {
@@ -181,7 +180,7 @@ function pick(
  * providers is a middleware that populates `ctx.providers` with provider information
  * @param opts
  */
-export function providers(opts?: ProvidersOpts): Middleware<ProviderContext> {
+export function providers(opts?: ProvidersOpts, supportedChains?: string[]): Middleware<ProviderContext> {
   let providers: Providers;
 
   return async (ctx: ProviderContext, next) => {
@@ -195,18 +194,18 @@ export function providers(opts?: ProvidersOpts): Middleware<ProviderContext> {
       // If no config is passed, we'll start providers for all default chains
       const environmentDefaultSupportedChains = defaultSupportedChains[ctx.env];
 
-      const defaultChains = opts.supportedChains
-        ? pick(environmentDefaultSupportedChains, opts.supportedChains)
+      const defaultChains = supportedChains
+        ? pick(environmentDefaultSupportedChains, supportedChains)
         : environmentDefaultSupportedChains;
 
-      const supportedChains = Object.assign(
+      const chains = Object.assign(
         {},
         defaultChains,
         opts?.chains,
       );
 
-      logger?.debug(`Providers initializing... ${JSON.stringify(supportedChains)}`);
-      providers = await buildProviders(supportedChains, logger);
+      logger?.debug(`Providers initializing... ${JSON.stringify(chains)}`);
+      providers = await buildProviders(chains, logger);
       logger?.debug(`Providers Initialized succesfully.`);
     }
 

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -250,7 +250,7 @@ async function buildProviders(
     } catch (error) {
       error.originalStack = error.stack;
       error.stack = new Error().stack;
-      logger?.error(`Failed to initialize provider for chain: ${chainIdStr} - endpoints: ${endpoints}. Error: ${error}`);
+      logger?.error(`Failed to initialize provider for chain: ${chainIdStr} - endpoints: ${endpoints}. Error: `, error);
       throw error;
     }
   }

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -131,12 +131,7 @@ const defaultSupportedChains = {
       websockets: [sui.testnetConnection.websocket],
     },
     [CHAIN_ID_SEI]: {
-      endpoints: [
-        // network is sei-devnet-3
-        "https://rpc.sei-devnet-3.seinetwork.io",
-        "https://sei_devnet-testnet-rpc.polkachu.com",
-        "https://sei-devnet-rpc.brocha.in",
-      ],
+      endpoints: ["https://sei-testnet-2-rpc.brocha.in"],
     },
     [CHAIN_ID_KLAYTN]: {
       endpoints: ["https://public-en-cypress.klaytn.net"],
@@ -206,7 +201,7 @@ export function providers(opts?: ProvidersOpts, supportedChains?: string[]): Mid
 
       logger?.debug(`Providers initializing... ${JSON.stringify(chains)}`);
       providers = await buildProviders(chains, logger);
-      logger?.debug(`Providers Initialized succesfully.`);
+      logger?.debug(`Providers initialized succesfully.`);
     }
 
     ctx.providers = providers;

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -214,11 +214,6 @@ async function buildProviders(
   supportedChains: Partial<ChainConfigInfo>,
   logger?: Logger,
 ): Promise<Providers> {
-  const supportedChains = Object.assign(
-    {},
-    defaultSupportedChains[env],
-    opts?.chains,
-  );
   const providers: Providers = {
     evm: {},
     solana: [],

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -159,16 +159,17 @@ const defaultSupportedChains = {
   },
 };
 
-function pick(
-  obj: Record<string, any>,
-  keys: string[],
-): any {
-  return keys.reduce((acc: Record<string, any>, key: string) => {
-    if (obj[key]) {
-      acc[key] = obj[key];
+function pick<T extends Object, Prop extends keyof T>(
+  obj: T,
+  keys: Prop[],
+): Pick<T, Prop> {
+  const res = {} as Pick<T, Prop>;
+  for (const key of keys) {
+    if (key in obj) {
+      res[key] = obj[key];
     }
-    return acc;
-  }, {});
+  };
+  return res;
 };
 
 /**


### PR DESCRIPTION
On monday we started getting errors with status-code 526, of the like:
![Screenshot from 2023-07-24 17-35-38](https://github.com/wormhole-foundation/relayer-engine/assets/12457451/91468c22-ee37-4988-9fab-7dca42a31053)
They were caused by the default sei provider declared on the RE having an expired SSL certificate.

To debug this, I noticed that the error stack is lost and the error logged is not very useful, so this PR:
- Adds the stack correct stack trace to the error
![Screenshot from 2023-07-24 23-10-55](https://github.com/wormhole-foundation/relayer-engine/assets/12457451/11fe5111-a0d5-4862-850b-4b94390531d3)

- Logs a friendlier message
![Screenshot from 2023-07-24 23-10-45](https://github.com/wormhole-foundation/relayer-engine/assets/12457451/76c00367-406b-4943-abe8-da4c24806009)

Also, something that made this difficult to debug, is that our relayer isn't really using SEI, so I didn't expect to see an error on the Sei provider.
This is because providers are started for all chains supported by the RE, instead of the actual chains in use by the RE.

This PR addresses this issue by adding a second, optional (to avoid a breaking change), parameter that allows to configure what chains are used by the relayer. 