### PR TITLE
[Feature] Add custom exponential backoff strategy with threshold

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,4 +39,5 @@ jobs:
         with:
           dry: True
           prettier_options: --write .
+          prettier_version: 2.8.4 # Fixed version to prevent breaking changes as creyD/prettier_action uses the latest available by default
           # github_token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/example-app/src/app.ts
+++ b/example-app/src/app.ts
@@ -93,7 +93,7 @@ async function main() {
       privateKeys,
       namespace,
       metrics: { enabled: true, registry: store.registry },
-    }),
+    })
   ); // <-- you need a valid private key to turn on this middleware
 
   app.use(tokenBridgeContracts());
@@ -104,7 +104,7 @@ async function main() {
     .chain(CHAIN_ID_SOLANA)
     .address(
       "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe",
-      fundsCtrl.processFundsTransfer,
+      fundsCtrl.processFundsTransfer
     );
 
   // Another way to do it if you want to listen to multiple addresses on different chains:
@@ -125,7 +125,7 @@ async function main() {
 
 function configRelayer<T extends Context>(
   app: RelayerApp<T>,
-  store: RedisStorage,
+  store: RedisStorage
 ) {
   app.spy("localhost:7073");
   app.useStorage(store);
@@ -136,7 +136,7 @@ function runUI(
   relayer: RelayerApp<any>,
   store: RedisStorage,
   { port }: any,
-  logger: Logger,
+  logger: Logger
 ) {
   const app = new Koa();
 

--- a/example-app/src/log.ts
+++ b/example-app/src/log.ts
@@ -13,6 +13,6 @@ export const rootLogger = winston.createLogger({
     winston.format.timestamp({
       format: "YYYY-MM-DD HH:mm:ss.SSS",
     }),
-    winston.format.errors({ stack: true }),
+    winston.format.errors({ stack: true })
   ),
 });

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -16,7 +16,7 @@ import {
 } from "./middleware";
 import { Logger } from "winston";
 import { StorageContext } from "./storage/storage";
-import { RedisStorage } from "./storage/redis-storage";
+import { ExponentialBackoffOpts, RedisStorage } from "./storage/redis-storage";
 import { ChainId } from "@certusone/wormhole-sdk";
 import { ClusterNode, ClusterOptions, RedisOptions } from "ioredis";
 import { mergeDeep } from "./utils";
@@ -44,6 +44,7 @@ export interface StandardRelayerAppOpts extends RelayerAppOpts {
   redisCluster?: ClusterOptions;
   redis?: RedisOptions;
   fetchSourceTxhash?: boolean;
+  exponentialBackoffStorageOptions?: ExponentialBackoffOpts;
 }
 
 const defaultOpts: Partial<StandardRelayerAppOpts> = {
@@ -83,6 +84,7 @@ export class StandardRelayerApp<
       redisCluster,
       redisClusterEndpoints,
       wormholeRpcs,
+      exponentialBackoffStorageOptions,
     } = opts;
     super(env, opts);
 
@@ -93,6 +95,7 @@ export class StandardRelayerApp<
       attempts: opts.workflows.retries ?? 3,
       namespace: name,
       queueName: `${name}-relays`,
+      exponentialBackoff: exponentialBackoffStorageOptions,
     });
 
     this.mergedRegistry = Registry.merge([

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -44,7 +44,7 @@ export interface StandardRelayerAppOpts extends RelayerAppOpts {
   redisCluster?: ClusterOptions;
   redis?: RedisOptions;
   fetchSourceTxhash?: boolean;
-  exponentialBackoffStorageOptions?: ExponentialBackoffOpts;
+  retryBackoffOptions?: ExponentialBackoffOpts;
 }
 
 const defaultOpts: Partial<StandardRelayerAppOpts> = {
@@ -84,7 +84,7 @@ export class StandardRelayerApp<
       redisCluster,
       redisClusterEndpoints,
       wormholeRpcs,
-      exponentialBackoffStorageOptions,
+      retryBackoffOptions,
     } = opts;
     super(env, opts);
 
@@ -95,7 +95,7 @@ export class StandardRelayerApp<
       attempts: opts.workflows.retries ?? 3,
       namespace: name,
       queueName: `${name}-relays`,
-      exponentialBackoff: exponentialBackoffStorageOptions,
+      exponentialBackoff: retryBackoffOptions,
     });
 
     this.mergedRegistry = Registry.merge([

--- a/relayer/bundle-fetcher.helper.ts
+++ b/relayer/bundle-fetcher.helper.ts
@@ -34,10 +34,7 @@ export class VaaBundleFetcher {
   private readonly fetchErrors: Record<string, Error> = {};
   private opts: VaaBundlerOpts;
 
-  constructor(
-    private fetchVaa: FetchVaaFn,
-    opts?: VaaBundlerOpts,
-  ) {
+  constructor(private fetchVaa: FetchVaaFn, opts?: VaaBundlerOpts) {
     this.opts = Object.assign({}, defaultOpts, opts);
 
     for (const id of this.opts.vaaIds) {

--- a/relayer/storage/redis-storage.ts
+++ b/relayer/storage/redis-storage.ts
@@ -71,7 +71,6 @@ export interface StorageOptions extends RedisConnectionOpts {
   queueName: string;
   attempts: number;
   concurrency?: number;
-  maxCompletedQueueSize?: number;
   exponentialBackoff?: ExponentialBackoffOpts;
 }
 

--- a/relayer/storage/redis-storage.ts
+++ b/relayer/storage/redis-storage.ts
@@ -174,6 +174,23 @@ export class RedisStorage implements Storage {
     this.logger?.debug(
       `Starting worker for queue: ${this.opts.queueName}. Prefix: ${this.prefix}.`,
     );
+
+    const workerSettings = this.opts.exponentialBackoff
+      ? {
+          settings: {
+            backoffStrategy: (attemptsMade: number) => {
+              const exponentialDelay =
+                Math.pow(2, attemptsMade) *
+                this.opts.exponentialBackoff?.baseDelayMs;
+              return Math.min(
+                exponentialDelay,
+                this.opts.exponentialBackoff?.maxDelayMs,
+              );
+            },
+          },
+        }
+      : undefined;
+
     this.worker = new Worker(
       this.opts.queueName,
       async job => {
@@ -209,17 +226,7 @@ export class RedisStorage implements Storage {
         prefix: this.prefix,
         connection: this.redis,
         concurrency: this.opts.concurrency,
-        settings: {
-          backoffStrategy: (attemptsMade: number) => {
-            const exponentialDelay =
-              Math.pow(2, attemptsMade) *
-              this.opts.exponentialBackoff?.baseDelayMs;
-            return Math.min(
-              exponentialDelay,
-              this.opts.exponentialBackoff?.maxDelayMs,
-            );
-          },
-        },
+        ...workerSettings,
       },
     );
     this.workerId = this.worker.id;

--- a/relayer/storage/redis-storage.ts
+++ b/relayer/storage/redis-storage.ts
@@ -181,10 +181,10 @@ export class RedisStorage implements Storage {
             backoffStrategy: (attemptsMade: number) => {
               const exponentialDelay =
                 Math.pow(2, attemptsMade) *
-                this.opts.exponentialBackoff?.baseDelayMs;
+                (this.opts.exponentialBackoff?.baseDelayMs || 1000);
               return Math.min(
                 exponentialDelay,
-                this.opts.exponentialBackoff?.maxDelayMs,
+                this.opts.exponentialBackoff?.maxDelayMs || 3_600_000, // 1 hour as default
               );
             },
           },

--- a/relayer/storage/redis-storage.ts
+++ b/relayer/storage/redis-storage.ts
@@ -64,6 +64,7 @@ export interface RedisConnectionOpts {
 export interface ExponentialBackoffOpts {
   baseDelayMs: number; // amount of time to apply each exp. backoff round
   maxDelayMs: number; // max amount of time to wait between retries
+  backOffFn?: (attemptsMade: number) => number; // custom backoff function
 }
 
 export interface StorageOptions extends RedisConnectionOpts {
@@ -175,18 +176,26 @@ export class RedisStorage implements Storage {
       `Starting worker for queue: ${this.opts.queueName}. Prefix: ${this.prefix}.`,
     );
 
+    // Use user provided backoff function if available, otherwise use xlabs default
+    let backOffFunction = undefined;
+    if (this.opts.exponentialBackoff?.backOffFn) {
+      backOffFunction = this.opts.exponentialBackoff.backOffFn;
+    } else {
+      backOffFunction = (attemptsMade: number) => {
+        const exponentialDelay =
+          Math.pow(2, attemptsMade) *
+          (this.opts.exponentialBackoff?.baseDelayMs || 1000);
+        return Math.min(
+          exponentialDelay,
+          this.opts.exponentialBackoff?.maxDelayMs || 3_600_000, // 1 hour as default
+        );
+      };
+    }
+
     const workerSettings = this.opts.exponentialBackoff
       ? {
           settings: {
-            backoffStrategy: (attemptsMade: number) => {
-              const exponentialDelay =
-                Math.pow(2, attemptsMade) *
-                (this.opts.exponentialBackoff?.baseDelayMs || 1000);
-              return Math.min(
-                exponentialDelay,
-                this.opts.exponentialBackoff?.maxDelayMs || 3_600_000, // 1 hour as default
-              );
-            },
+            backoffStrategy: backOffFunction,
           },
         }
       : undefined;

--- a/relayer/storage/redis-storage.ts
+++ b/relayer/storage/redis-storage.ts
@@ -62,8 +62,8 @@ export interface RedisConnectionOpts {
 }
 
 export interface ExponentialBackoffOpts {
-  attemptsThreshold: number; // after this many attempts, the delay will be constant
-  delayMs: number;
+  baseDelayMs: number; // amount of time to apply each exp. backoff round
+  maxDelayMs: number; // max amount of time to wait between retries
 }
 
 export interface StorageOptions extends RedisConnectionOpts {
@@ -211,13 +211,12 @@ export class RedisStorage implements Storage {
         concurrency: this.opts.concurrency,
         settings: {
           backoffStrategy: (attemptsMade: number) => {
-            const attempts =
-              attemptsMade >= this.opts.exponentialBackoff?.attemptsThreshold
-                ? this.opts.exponentialBackoff?.attemptsThreshold
-                : attemptsMade;
-
-            return (
-              Math.pow(2, attempts) * this.opts.exponentialBackoff?.delayMs
+            const exponentialDelay =
+              Math.pow(2, attemptsMade) *
+              this.opts.exponentialBackoff?.baseDelayMs;
+            return Math.min(
+              exponentialDelay,
+              this.opts.exponentialBackoff?.maxDelayMs,
             );
           },
         },

--- a/relayer/utils.ts
+++ b/relayer/utils.ts
@@ -108,10 +108,7 @@ export const minute = 60 * second;
 export const hour = 60 * minute;
 
 export class EngineError extends Error {
-  constructor(
-    msg: string,
-    public args?: Record<any, any>,
-  ) {
+  constructor(msg: string, public args?: Record<any, any>) {
     super(msg);
   }
 }


### PR DESCRIPTION
Adds a custom exponential backoff with threshold strategy. Although bullmq supports exponential backoff, it does not allow stopping the continuously increasing delay.

In this implementation, `baseDelayMs` will be increased exponentially on each retry attempt, until it reaches `maxDelayMs`, which will be the constant delay applied onwards.