### PR TITLE
Add processing duration metric + customization

### DIFF
--- a/relayer/context.ts
+++ b/relayer/context.ts
@@ -6,7 +6,6 @@ import {
   RelayerEvents,
 } from "./application";
 import { Logger } from "winston";
-import { ChainID } from "@certusone/wormhole-spydk/lib/cjs/proto/publicrpc/v1/publicrpc";
 import { Environment } from "./environment";
 
 export type FetchVaaFn = (

--- a/relayer/middleware/metrics.middleware.ts
+++ b/relayer/middleware/metrics.middleware.ts
@@ -3,7 +3,6 @@ import { Middleware } from "../compose.middleware";
 import { StorageContext } from "../storage/storage";
 import { Counter, Registry } from "prom-client";
 
-
 type MetricRecord = Record<string, string | number>;
 
 export interface MetricsOpts<C extends StorageContext> {
@@ -16,84 +15,101 @@ export class MetricLabelsOpts<C extends StorageContext> {
   labelNames: string[];
   customizer: (context: C) => Promise<MetricRecord>;
 
-  constructor(labelNames: string[] = [], customizer: (ctx: C) => Promise<MetricRecord>) {
+  constructor(
+    labelNames: string[] = [],
+    customizer: (ctx: C) => Promise<MetricRecord>,
+  ) {
     this.labelNames = labelNames;
     this.customizer = customizer;
   }
 }
 
+const getLabels = async <C extends StorageContext>(
+  ctx: C,
+  opts: MetricsOpts<C>,
+  failed: boolean,
+) => {
+  const defaultLabels = { status: failed ? "failed" : "succeeded" };
+
+  try {
+    const labels: MetricRecord = await (opts.labels?.customizer(ctx) ??
+      Promise.resolve({}));
+
+    const allowedKeys = opts.labels?.labelNames ?? [];
+    const validatedLabels: typeof labels = {};
+    allowedKeys.forEach(key => {
+      if (labels[key]) {
+        validatedLabels[key] = labels[key];
+      }
+    });
+
+    return { ...validatedLabels, ...defaultLabels };
+  } catch (error) {
+    ctx.logger?.error(
+      "Failed to customize metric labels, please review",
+      error,
+    );
+
+    return defaultLabels;
+  }
+};
+
 export function metrics<C extends StorageContext>(
-  opts: MetricsOpts<C> = { },
+  opts: MetricsOpts<C> = {},
 ): Middleware<C> {
   opts.registry = opts.registry || register;
-
-
-  const getLabels = async (ctx: C, failed: boolean) => {
-    const defaultLabels = { status: failed ? "failed" : "succeeded" };
-
-    try {
-      const labels: MetricRecord = await (opts.labels?.customizer(ctx) ?? Promise.resolve({}));
-
-      const allowedKeys = opts.labels?.labelNames ?? [];
-      const validatedLabels: typeof labels = {};
-      allowedKeys.forEach(key => {
-        if (labels[key]) {
-          validatedLabels[key] = labels[key];
-        }
-      });
-
-      return { ...validatedLabels, ...defaultLabels };
-    } catch (error) {
-      ctx.logger?.error("Failed to customize metric labels, please review", error);
-
-      return defaultLabels;
-    }
-  }
 
   const processedVaasTotal = new Counter({
     name: "vaas_processed_total",
     help: "Number of incoming vaas processed successfully or unsuccessfully.",
-    labelNames: opts.labels?.labelNames ?? [],
+    labelNames: ["status"].concat(opts.labels?.labelNames ?? []),
     registers: [opts.registry],
   });
 
   const finishedVaasTotal = new Counter({
     name: "vaas_finished_total",
     help: "Number of vaas processed successfully or unsuccessfully.",
-    labelNames: ["status"].concat(opts.labels?.labelNames ?? []),
+    labelNames: ["status", "terminal"].concat(opts.labels?.labelNames ?? []),
     registers: [opts.registry],
   });
 
   const processingDuration = new Histogram({
-    name: `vaas_processing_duration`,
+    name: "vaas_processing_duration",
     help: "Processing time in ms for jobs",
-    buckets: opts.processingTimeBuckets ?? [6000, 7000, 7500, 8000, 8500, 9000, 10000, 12000],
+    buckets: opts.processingTimeBuckets ?? [
+      6000, 7000, 7500, 8000, 8500, 9000, 10000, 12000,
+    ],
     labelNames: ["status"].concat(opts.labels?.labelNames ?? []),
     registers: [opts.registry],
   });
 
   return async (ctx: C, next) => {
+    processedVaasTotal.inc();
+
     const startTime = Date.now();
     let failure: Error = null;
-    processedVaasTotal.inc();
 
     try {
       await next();
     } catch (e) {
-      failure = e; // TODO: test failure case
+      failure = e;
     }
 
     const time = Date.now() - startTime;
-    const labels = await getLabels(ctx, failure !== null);
+    const labels = await getLabels(ctx, opts, failure !== null);
+    processingDuration.labels(labels).observe(time);
 
     if (failure) {
-      processingDuration.labels(labels).observe(time);
-      finishedVaasTotal.labels(labels).inc();
+      const reachedMaxAttempts =
+        (ctx.storage.job?.attempts ?? 0) ===
+        (ctx.storage.job?.maxAttempts ?? -1);
+      finishedVaasTotal
+        .labels({ ...labels, terminal: `${reachedMaxAttempts}` })
+        .inc();
 
-      throw failure
+      throw failure;
     }
 
-    processingDuration.labels(labels).observe(time);
     finishedVaasTotal.labels(labels).inc();
   };
 }

--- a/relayer/middleware/metrics.middleware.ts
+++ b/relayer/middleware/metrics.middleware.ts
@@ -4,6 +4,7 @@ import { RelayJob, StorageContext } from "../storage/storage";
 import { Counter, Registry } from "prom-client";
 
 type MetricRecord = Record<string, string | number>;
+const defaultTimeBuckets = [6000, 7000, 7500, 8000, 8500, 9000, 10000, 12000];
 
 class MeasuredRelayJob {
   private job?: RelayJob;
@@ -106,7 +107,7 @@ export function metrics<C extends StorageContext>(
   const processedVaasTotal = new Counter({
     name: "vaas_processed_total",
     help: "Number of incoming vaas processed successfully or unsuccessfully.",
-    labelNames: [].concat(opts.labels?.labelNames ?? []),
+    labelNames: opts.labels?.labelNames ?? [],
     registers: [opts.registry],
   });
 
@@ -120,9 +121,7 @@ export function metrics<C extends StorageContext>(
   const processingDuration = new Histogram({
     name: "vaas_processing_duration",
     help: "Processing time in ms for jobs",
-    buckets: opts.processingTimeBuckets ?? [
-      6000, 7000, 7500, 8000, 8500, 9000, 10000, 12000,
-    ],
+    buckets: opts.processingTimeBuckets ?? defaultTimeBuckets,
     labelNames: [status].concat(opts.labels?.labelNames ?? []),
     registers: [opts.registry],
   });
@@ -130,9 +129,7 @@ export function metrics<C extends StorageContext>(
   const totalDuration = new Histogram({
     name: "vaas_total_duration",
     help: "Processing time in ms for relaying",
-    buckets: opts.processingTimeBuckets ?? [
-      6000, 7000, 7500, 8000, 8500, 9000, 10000, 12000,
-    ],
+    buckets: opts.processingTimeBuckets ?? defaultTimeBuckets,
     labelNames: [status].concat(opts.labels?.labelNames ?? []),
     registers: [opts.registry],
   });

--- a/relayer/middleware/metrics.middleware.ts
+++ b/relayer/middleware/metrics.middleware.ts
@@ -1,5 +1,5 @@
 import { Histogram, register } from "prom-client";
-import { Middleware } from "../compose.middleware";
+import { Middleware, Next } from "../compose.middleware";
 import { RelayJob, StorageContext } from "../storage/storage";
 import { Counter, Registry } from "prom-client";
 
@@ -129,7 +129,7 @@ export function metrics<C extends StorageContext>(
     registers: [opts.registry],
   });
 
-  return async (ctx: C, next) => {
+  const metricsMiddleware = async (ctx: C, next: Next) => {
     processedVaasTotal.inc();
     let failure: Error = null;
 
@@ -160,4 +160,6 @@ export function metrics<C extends StorageContext>(
 
     finishedVaasTotal.labels(labels).inc();
   };
+
+  return metricsMiddleware;
 }

--- a/relayer/middleware/metrics.middleware.ts
+++ b/relayer/middleware/metrics.middleware.ts
@@ -1,45 +1,99 @@
-import { register } from "prom-client";
+import { Histogram, register } from "prom-client";
 import { Middleware } from "../compose.middleware";
-import { Context } from "../context";
 import { StorageContext } from "../storage/storage";
-import { Job } from "bullmq";
 import { Counter, Registry } from "prom-client";
 
-interface MetricsOpts {
+
+type MetricRecord = Record<string, string | number>;
+
+export interface MetricsOpts<C extends StorageContext> {
   registry?: Registry;
+  labels?: MetricLabelsOpts<C>;
+  processingTimeBuckets?: number[];
 }
 
-export function metrics(
-  opts: MetricsOpts = {},
-): Middleware<Context & { job?: Job }> {
+export class MetricLabelsOpts<C extends StorageContext> {
+  labelNames: string[];
+  customizer: (context: C) => Promise<MetricRecord>;
+
+  constructor(labelNames: string[] = [], customizer: (ctx: C) => Promise<MetricRecord>) {
+    this.labelNames = labelNames;
+    this.customizer = customizer;
+  }
+}
+
+export function metrics<C extends StorageContext>(
+  opts: MetricsOpts<C> = { },
+): Middleware<C> {
   opts.registry = opts.registry || register;
+
+
+  const getLabels = async (ctx: C, failed: boolean) => {
+    const defaultLabels = { status: failed ? "failed" : "succeeded" };
+
+    try {
+      const labels: MetricRecord = await (opts.labels?.customizer(ctx) ?? Promise.resolve({}));
+
+      const allowedKeys = opts.labels?.labelNames ?? [];
+      const validatedLabels: typeof labels = {};
+      allowedKeys.forEach(key => {
+        if (labels[key]) {
+          validatedLabels[key] = labels[key];
+        }
+      });
+
+      return { ...validatedLabels, ...defaultLabels };
+    } catch (error) {
+      ctx.logger?.error("Failed to customize metric labels, please review", error);
+
+      return defaultLabels;
+    }
+  }
+
   const processedVaasTotal = new Counter({
     name: "vaas_processed_total",
-    help: "Number of vaas processed successfully or unsuccessfully.",
+    help: "Number of incoming vaas processed successfully or unsuccessfully.",
+    labelNames: opts.labels?.labelNames ?? [],
     registers: [opts.registry],
   });
 
   const finishedVaasTotal = new Counter({
     name: "vaas_finished_total",
     help: "Number of vaas processed successfully or unsuccessfully.",
-    labelNames: ["status"],
+    labelNames: ["status"].concat(opts.labels?.labelNames ?? []),
     registers: [opts.registry],
   });
 
-  return async (ctx: StorageContext, next) => {
-    const job = ctx.storage?.job;
-    // disable this metric if storage is enabled because the storage will actually compute the metrics.
-    if (job) {
-      await next();
-      return;
-    }
+  const processingDuration = new Histogram({
+    name: `vaas_processing_duration`,
+    help: "Processing time in ms for jobs",
+    buckets: opts.processingTimeBuckets ?? [6000, 7000, 7500, 8000, 8500, 9000, 10000, 12000],
+    labelNames: ["status"].concat(opts.labels?.labelNames ?? []),
+    registers: [opts.registry],
+  });
 
+  return async (ctx: C, next) => {
+    const startTime = Date.now();
+    let failure: Error = null;
     processedVaasTotal.inc();
+
     try {
       await next();
-      finishedVaasTotal.labels({ status: "succeeded" }).inc();
     } catch (e) {
-      finishedVaasTotal.labels({ status: "failed" }).inc();
+      failure = e; // TODO: test failure case
     }
+
+    const time = Date.now() - startTime;
+    const labels = await getLabels(ctx, failure !== null);
+
+    if (failure) {
+      processingDuration.labels(labels).observe(time);
+      finishedVaasTotal.labels(labels).inc();
+
+      throw failure
+    }
+
+    processingDuration.labels(labels).observe(time);
+    finishedVaasTotal.labels(labels).inc();
   };
 }

--- a/relayer/middleware/metrics.middleware.ts
+++ b/relayer/middleware/metrics.middleware.ts
@@ -16,13 +16,21 @@ class MeasuredRelayJob {
     this.endTime = endTime;
   }
 
+  private currentAttempts(): number {
+    return this.job?.attempts ?? 0;
+  }
+
+  private maxAttempts(): number {
+    return this.job?.maxAttempts ?? Number.MAX_SAFE_INTEGER;
+  }
+
   hasReachedMaxAttempts(): boolean {
-    return (this.job?.attempts ?? 0) === (this.job?.maxAttempts ?? -1);
+    return this.currentAttempts() >= this.maxAttempts();
   }
 
   vaaTimestamp(): number {
     // vaa.timestamp is in seconds
-    return this.job?.data?.parsedVaa?.timestamp * 1000 ?? -1;
+    return this.job?.data?.parsedVaa?.timestamp * 1000 ?? 0;
   }
 
   processingTime(): number {
@@ -34,7 +42,7 @@ class MeasuredRelayJob {
       return this.endTime - this.vaaTimestamp();
     }
 
-    return -1;
+    return 0;
   }
 }
 

--- a/relayer/storage/storage.ts
+++ b/relayer/storage/storage.ts
@@ -1,4 +1,3 @@
-import { Registry } from "prom-client";
 import { Context } from "../context";
 import { ParsedVaa, SignedVaa } from "@certusone/wormhole-sdk";
 

--- a/test/middleware/metrics.middleware.test.ts
+++ b/test/middleware/metrics.middleware.test.ts
@@ -1,10 +1,10 @@
-import {
-    beforeEach,
-    describe,
-    test
-} from "@jest/globals";
+import { beforeEach, describe, test } from "@jest/globals";
 import { Registry } from "prom-client";
-import { MetricLabelsOpts, metrics, MetricsOpts } from "../../relayer/middleware/metrics.middleware";
+import {
+  MetricLabelsOpts,
+  metrics,
+  MetricsOpts,
+} from "../../relayer/middleware/metrics.middleware";
 import { Middleware, Next } from "../../relayer/compose.middleware";
 import { parseVaa } from "@certusone/wormhole-sdk";
 import { StorageContext } from "../../relayer/storage/storage";
@@ -13,9 +13,11 @@ import { Environment } from "../../relayer/environment";
 
 type TestContext = StorageContext & { target?: string };
 
-const vaa = Buffer.from("AQAAAAABAGYGQ1g8mB5UMkeq28zodCdhDUk8YSjRSseFmP3VkKHMDUuZmDpQ6ccsPSx+bUkDIDp+ud6Qfes9nvZcWHkH1tQAZNPDWAg9AQAAAgAAAAAAAAAAAAAAAPiQmC+TEN9X0A9lnPT9h+Za3tjXAAAAAAACh1YBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPoAAAAAAAAAAAAAAAAtPvycRQ/T797kaXe0xgF5CsiCNYAAgAAAAAAAAAAAAAAAI8moAJdzMbPwHp9OHVigKEOKVrXAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", "base64");
-
-const nextProvider: (implementation?: () => void) => Next = (implementation = () => { }) => jest.fn().mockImplementation(() => Promise.resolve(implementation()));
+const vaa = Buffer.from(
+  "AQAAAAABAGYGQ1g8mB5UMkeq28zodCdhDUk8YSjRSseFmP3VkKHMDUuZmDpQ6ccsPSx+bUkDIDp+ud6Qfes9nvZcWHkH1tQAZNPDWAg9AQAAAgAAAAAAAAAAAAAAAPiQmC+TEN9X0A9lnPT9h+Za3tjXAAAAAAACh1YBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPoAAAAAAAAAAAAAAAAtPvycRQ/T797kaXe0xgF5CsiCNYAAgAAAAAAAAAAAAAAAI8moAJdzMbPwHp9OHVigKEOKVrXAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+  "base64",
+);
+const targetLabel = "targetLabel";
 
 let ctx: TestContext;
 let middleware: Middleware<TestContext> | null;
@@ -24,99 +26,163 @@ let labelOpts: MetricLabelsOpts<TestContext>;
 let next: Next;
 
 describe("metrics middleware", () => {
+  beforeEach(() => {
+    registry.clear();
+    middleware = null;
+  });
 
-    beforeEach(() => {
-        registry.clear();
-        middleware = null;
+  test("should expose known metrics", async () => {
+    givenAMetricsMiddleware();
+    givenAContext();
+    const next = nextProvider();
+
+    await whenExecuted(next);
+
+    thenNextCalled(next);
+    await thenMetricPresent("vaas_processed_total", val => expect(val).toBe(1));
+    await thenMetricPresent(
+      "vaas_finished_total",
+      val => expect(val).toBe(1),
+      true,
+    );
+  });
+
+  test("should expose time histogram", async () => {
+    givenAMetricsMiddleware();
+    givenAContext();
+
+    await whenExecuted(nextProvider());
+
+    await thenMetricPresent(
+      "vaas_processing_duration",
+      val => expect(val).toBeGreaterThan(0),
+      true,
+    );
+  });
+
+  test("should allow to customize labels", async () => {
+    const expectedTarget = "base";
+    givenAMetricsMiddleware({
+      labels: { labelNames: [targetLabel], customizer: targetCustomizer },
     });
+    givenAContext();
 
-    test("should expose known metrics", async () => {
-        givenAMetricsMiddleware();
-        givenAContext();
-        const next = nextProvider();
+    await whenExecuted(
+      nextProvider(() => {
+        ctx.target = expectedTarget;
+      }),
+    );
 
-        await whenExecuted(next);
+    await thenMetricPresent(
+      "vaas_processing_duration",
+      (val, labels) => {
+        expect(val).toBeGreaterThan(0);
+        expect(labels[targetLabel]).toBe(expectedTarget);
+      },
+      true,
+    );
+  });
 
-        thenNextCalled(next);
-        await thenMetricPresent("vaas_processed_total", (val) => expect(val).toBe(1));
-        await thenMetricPresent("vaas_finished_total", (val) => expect(val).toBe(1), true);
+  test("should measure failures", async () => {
+    const expectedTarget = "celo";
+    givenAMetricsMiddleware({
+      labels: { labelNames: [targetLabel], customizer: targetCustomizer },
     });
+    givenAContext();
 
-    test("should expose time histogram", async () => {
-        givenAMetricsMiddleware();
-        givenAContext();
+    await whenExecuted(
+      nextProvider(() => {
+        ctx.target = expectedTarget;
+        throw new Error("runtime failure");
+      }),
+    );
 
-        await whenExecuted(nextProvider());
-
-        await thenMetricPresent("vaas_processing_duration", (val) => expect(val).toBeGreaterThan(0), true);
-    });
-
-    test("should allow to customize labels", async () => {
-        const expectedTarget = "base";
-        const labelName = "targetLabel";
-        givenAMetricsMiddleware({ labels: { labelNames: [labelName], customizer: targetCustomizer } });
-        givenAContext();
-
-        await whenExecuted(nextProvider(() => { ctx.target = expectedTarget; }));
-
-        await thenMetricPresent(
-            "vaas_processing_duration",
-            (val, labels) => {
-                expect(val).toBeGreaterThan(0);
-                expect(labels[labelName]).toBe(expectedTarget);
-            },
-            true
-        );
-    });
+    await thenMetricPresent(
+      "vaas_finished_total",
+      (val, labels) => {
+        expect(val).toBe(1);
+        expect(labels.status).toBe("failed");
+        expect(labels.terminal).toBe("true");
+        expect(labels[targetLabel]).toBe(expectedTarget);
+      },
+      false,
+    );
+    await thenMetricPresent(
+      "vaas_processing_duration",
+      (val, labels) => {
+        expect(val).toBeGreaterThan(0);
+        expect(labels.status).toBe("failed");
+        expect(labels[targetLabel]).toBe(expectedTarget);
+      },
+      false,
+    );
+  });
 });
 
 const createContext = () => ({
-    storage: { job: createRelayJob() },
-    locals: {},
-    fetchVaa: () => Promise.resolve({} as ParsedVaaWithBytes),
-    fetchVaas: () => Promise.resolve([]),
-    processVaa: () => Promise.resolve(),
-    config: { spyFilters: [{}] },
-    env: Environment.DEVNET,
-    on: () => { }
+  storage: { job: createRelayJob() },
+  locals: {},
+  fetchVaa: () => Promise.resolve({} as ParsedVaaWithBytes),
+  fetchVaas: () => Promise.resolve([]),
+  processVaa: () => Promise.resolve(),
+  config: { spyFilters: [{}] },
+  env: Environment.DEVNET,
+  on: () => {},
 });
 
-const targetCustomizer = (ctx: TestContext) => Promise.resolve({ targetLabel: ctx.target ?? 0 });
+const targetCustomizer = (ctx: TestContext) =>
+  Promise.resolve({ targetLabel: ctx.target ?? 0 });
 
 const createRelayJob = () => ({
-    id: "id",
-    name: "name",
-    data: {
-        vaaBytes: vaa,
-        parsedVaa: parseVaa(vaa)
-    },
-    attempts: 0,
-    maxAttempts: 1,
-    log: (logRow: string) => Promise.resolve(5),
-    updateProgress: (progress: number | object) => Promise.resolve()
+  id: "id",
+  name: "name",
+  data: {
+    vaaBytes: vaa,
+    parsedVaa: parseVaa(vaa),
+  },
+  attempts: 1,
+  maxAttempts: 1,
+  log: (logRow: string) => Promise.resolve(5),
+  updateProgress: (progress: number | object) => Promise.resolve(),
 });
 
+const nextProvider: (implementation?: () => void) => Next = (
+  implementation = () => {},
+) => jest.fn().mockImplementation(() => Promise.resolve(implementation()));
+
 const givenAMetricsMiddleware = (opts: MetricsOpts<TestContext> = {}) => {
-    middleware = metrics<TestContext>({ registry, ...opts })
+  middleware = metrics<TestContext>({ registry, ...opts });
 };
 
-const givenAContext = () => ctx = createContext();
+const givenAContext = () => (ctx = createContext());
 
-const whenExecuted = async (next: Next) => await middleware!(ctx, next);
+const whenExecuted = async (next: Next) => {
+  try {
+    await middleware!(ctx, next);
+  } catch (error) {
+    // ignoring it
+  }
+};
 
 const thenMetricPresent = async (
-    metric: string,
-    expectation: (value: any, labels: Partial<Record<string, string | number>>) => void,
-    withStatus: boolean = false) => {
-    const metricValue = (await registry.getSingleMetric(metric)!.get()).values[0];
-    expect(metricValue).toBeDefined();
-    expectation(metricValue.value, metricValue.labels);
-    if (withStatus) {
-        expect(metricValue.labels["status"]).toBeDefined();
-    }
-    labelOpts?.labelNames!.forEach(labelName => expect(metricValue.labels[labelName]).toBeDefined());
+  metric: string,
+  expectation: (
+    value: any,
+    labels: Partial<Record<string, string | number>>,
+  ) => void,
+  withStatus: boolean = false,
+) => {
+  const metricValue = (await registry.getSingleMetric(metric)!.get()).values[0];
+  expect(metricValue).toBeDefined();
+  expectation(metricValue.value, metricValue.labels);
+  if (withStatus) {
+    expect(metricValue.labels["status"]).toBeDefined();
+  }
+  labelOpts?.labelNames!.forEach(labelName =>
+    expect(metricValue.labels[labelName]).toBeDefined(),
+  );
 };
 
 const thenNextCalled = (next: Next) => {
-    expect(next).toHaveBeenCalledTimes(1);
+  expect(next).toHaveBeenCalledTimes(1);
 };

--- a/test/middleware/metrics.middleware.test.ts
+++ b/test/middleware/metrics.middleware.test.ts
@@ -1,0 +1,122 @@
+import {
+    beforeEach,
+    describe,
+    test
+} from "@jest/globals";
+import { Registry } from "prom-client";
+import { MetricLabelsOpts, metrics, MetricsOpts } from "../../relayer/middleware/metrics.middleware";
+import { Middleware, Next } from "../../relayer/compose.middleware";
+import { parseVaa } from "@certusone/wormhole-sdk";
+import { StorageContext } from "../../relayer/storage/storage";
+import { ParsedVaaWithBytes } from "../../relayer/application";
+import { Environment } from "../../relayer/environment";
+
+type TestContext = StorageContext & { target?: string };
+
+const vaa = Buffer.from("AQAAAAABAGYGQ1g8mB5UMkeq28zodCdhDUk8YSjRSseFmP3VkKHMDUuZmDpQ6ccsPSx+bUkDIDp+ud6Qfes9nvZcWHkH1tQAZNPDWAg9AQAAAgAAAAAAAAAAAAAAAPiQmC+TEN9X0A9lnPT9h+Za3tjXAAAAAAACh1YBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPoAAAAAAAAAAAAAAAAtPvycRQ/T797kaXe0xgF5CsiCNYAAgAAAAAAAAAAAAAAAI8moAJdzMbPwHp9OHVigKEOKVrXAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", "base64");
+
+const nextProvider: (implementation?: () => void) => Next = (implementation = () => { }) => jest.fn().mockImplementation(() => Promise.resolve(implementation()));
+
+let ctx: TestContext;
+let middleware: Middleware<TestContext> | null;
+const registry: Registry = new Registry();
+let labelOpts: MetricLabelsOpts<TestContext>;
+let next: Next;
+
+describe("metrics middleware", () => {
+
+    beforeEach(() => {
+        registry.clear();
+        middleware = null;
+    });
+
+    test("should expose known metrics", async () => {
+        givenAMetricsMiddleware();
+        givenAContext();
+        const next = nextProvider();
+
+        await whenExecuted(next);
+
+        thenNextCalled(next);
+        await thenMetricPresent("vaas_processed_total", (val) => expect(val).toBe(1));
+        await thenMetricPresent("vaas_finished_total", (val) => expect(val).toBe(1), true);
+    });
+
+    test("should expose time histogram", async () => {
+        givenAMetricsMiddleware();
+        givenAContext();
+
+        await whenExecuted(nextProvider());
+
+        await thenMetricPresent("vaas_processing_duration", (val) => expect(val).toBeGreaterThan(0), true);
+    });
+
+    test("should allow to customize labels", async () => {
+        const expectedTarget = "base";
+        const labelName = "targetLabel";
+        givenAMetricsMiddleware({ labels: { labelNames: [labelName], customizer: targetCustomizer } });
+        givenAContext();
+
+        await whenExecuted(nextProvider(() => { ctx.target = expectedTarget; }));
+
+        await thenMetricPresent(
+            "vaas_processing_duration",
+            (val, labels) => {
+                expect(val).toBeGreaterThan(0);
+                expect(labels[labelName]).toBe(expectedTarget);
+            },
+            true
+        );
+    });
+});
+
+const createContext = () => ({
+    storage: { job: createRelayJob() },
+    locals: {},
+    fetchVaa: () => Promise.resolve({} as ParsedVaaWithBytes),
+    fetchVaas: () => Promise.resolve([]),
+    processVaa: () => Promise.resolve(),
+    config: { spyFilters: [{}] },
+    env: Environment.DEVNET,
+    on: () => { }
+});
+
+const targetCustomizer = (ctx: TestContext) => Promise.resolve({ targetLabel: ctx.target ?? 0 });
+
+const createRelayJob = () => ({
+    id: "id",
+    name: "name",
+    data: {
+        vaaBytes: vaa,
+        parsedVaa: parseVaa(vaa)
+    },
+    attempts: 0,
+    maxAttempts: 1,
+    log: (logRow: string) => Promise.resolve(5),
+    updateProgress: (progress: number | object) => Promise.resolve()
+});
+
+const givenAMetricsMiddleware = (opts: MetricsOpts<TestContext> = {}) => {
+    middleware = metrics<TestContext>({ registry, ...opts })
+};
+
+const givenAContext = () => ctx = createContext();
+
+const whenExecuted = async (next: Next) => await middleware!(ctx, next);
+
+const thenMetricPresent = async (
+    metric: string,
+    expectation: (value: any, labels: Partial<Record<string, string | number>>) => void,
+    withStatus: boolean = false) => {
+    const metricValue = (await registry.getSingleMetric(metric)!.get()).values[0];
+    expect(metricValue).toBeDefined();
+    expectation(metricValue.value, metricValue.labels);
+    if (withStatus) {
+        expect(metricValue.labels["status"]).toBeDefined();
+    }
+    labelOpts?.labelNames!.forEach(labelName => expect(metricValue.labels[labelName]).toBeDefined());
+};
+
+const thenNextCalled = (next: Next) => {
+    expect(next).toHaveBeenCalledTimes(1);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "node_modules",
     "relayer/lib/**/*",
     "**/__tests__/*",
-    "relayer/src/**/*.test.ts"
+    "relayer/**/*.test.ts",
+    "test/*"
   ]
 }


### PR DESCRIPTION
Enhances current metric middleware with the following features:
- expose processing duration (both success and failures via labeling)
- expose total duration
- add labels customization based on context
- add terminal label on vaas_finished_total

Usage example:
``` import { MetricLabelsOpts, MetricsOpts, metrics } from "@wormhole-foundation/relayer-engine";
import { Context } from "../app";
import { Registry } from "prom-client";
import { ChainId, coalesceChainName } from "@certusone/wormhole-sdk";

const metricsOpts = (registry: Registry): MetricsOpts<Context> => {
    function labelsCustomizer(ctx: Context): Promise<Record<string, string | number>> {
        const chainId = ctx.executionRecord.deliveryRecord.chainId as ChainId;

        return Promise.resolve({
            targetChain: coalesceChainName(chainId)
        });
    }

    const labelOpts = new MetricLabelsOpts<Context>(["targetChain"], labelsCustomizer);

    return {
        registry,
        labels: labelOpts,
        processingTimeBuckets: [
            10000, // 10s
            20000, // 20s
            30000, // 30s
            60000, // 60s
            240000, // 4m
            600000, // 10m
            1200000, // 20m
            3600000 // 1h
        ]
    };
};

export function metricsMiddleware(registry: Registry) {
    return metrics(metricsOpts(registry));
};
```