### PR TITLE
Mask BlockDaemon RPC endpoints in logs

### DIFF
--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -278,7 +278,7 @@ function maskRPCEndpoints(endpoints: string[]) {
   return endpoints.map((url: string) => {
     const apiKeyPos = url.indexOf("apiKey");
     if (apiKeyPos > -1) {
-      // Found API secret key in the RPC url, show initial 3 chars and mask the rest
+      // Found API key in the RPC url, show only initial 3 chars and mask the rest
       return url.substring(0, apiKeyPos + 10) + "***";
     }
     return url;

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -202,7 +202,9 @@ export function providers(
 
       const chains = Object.assign({}, defaultChains, opts?.chains);
 
-      logger?.debug(`Providers initializing... ${JSON.stringify(chains)}`);
+      logger?.debug(
+        `Providers initializing... ${JSON.stringify(maskRPCProviders(chains))}`,
+      );
       providers = await buildProviders(chains, logger);
       logger?.debug(`Providers initialized succesfully.`);
     }
@@ -260,7 +262,9 @@ async function buildProviders(
       error.originalStack = error.stack;
       error.stack = new Error().stack;
       logger?.error(
-        `Failed to initialize provider for chain: ${chainIdStr} - endpoints: ${endpoints}. Error: `,
+        `Failed to initialize provider for chain: ${chainIdStr} - endpoints: ${maskRPCEndpoints(
+          endpoints,
+        )}. Error: `,
         error,
       );
       throw error;
@@ -268,4 +272,25 @@ async function buildProviders(
   }
 
   return providers;
+}
+
+function maskRPCEndpoints(endpoints: string[]) {
+  return endpoints.map((url: string) => {
+    const apiKeyPos = url.indexOf("apiKey");
+    if (apiKeyPos > -1) {
+      // Found API secret key in the RPC url, show initial 3 chars and mask the rest
+      return url.substring(0, apiKeyPos + 10) + "***";
+    }
+    return url;
+  });
+}
+
+function maskRPCProviders(chains: Partial<ChainConfigInfo>) {
+  const maskedChains: Partial<ChainConfigInfo> = {};
+  for (const [chainId, chainConfig] of Object.entries(chains)) {
+    maskedChains[chainId as unknown as ChainId] = {
+      endpoints: maskRPCEndpoints(chainConfig.endpoints),
+    };
+  }
+  return maskedChains;
 }


### PR DESCRIPTION
## description

Adds a small functionality to mask sensitive Blockdaemon RPC urls from being logged.

## Testing

Tested the snippet separately passing data, works well.
<img width="1512" alt="Screenshot 2023-08-24 at 4 55 31 PM" src="https://github.com/wormhole-foundation/relayer-engine/assets/22657248/3dbfd951-d3dc-4213-a16d-8a4385484401">
