### PR TITLE
Revert "Use prepack instead of prepare for yarn compat (#169)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "prettier --write $(git diff main --name-only --diff-filter u | grep '.ts$' | xargs)",
     "mainnet-spy": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/mainnet/2 --bootstrap /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7",
     "testnet-spy": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/testnet/2/1 --bootstrap /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWAkB9ynDur1Jtoa97LBUp8RXdhzS5uHgAfdTquJbrbN7i",
-    "prepack": "npm run build"
+    "prepare": "npm run build"
   },
   "author": "Joe Howarth",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts commit 80e232e3ab0fb34cce681d2c2b5656e68464d5a2.

Some integrators reported having their build pipeline broke by the change. Currently I don't have capacity to find a solution that works both for yarn and npm, so I'm resorting to reverting the change. Do we have reasons to believe reverting this change might break some other integrators code?