### PR TITLE
Add max look-ahead capability

### DIFF
--- a/relayer/middleware/missedVaasV3/check.ts
+++ b/relayer/middleware/missedVaasV3/check.ts
@@ -164,7 +164,7 @@ export async function checkForMissedVaas(
         : startingSeqConfig // same as Math.max, which doesn't support bigint
       : lastSeq || startingSeqConfig;
 
-  const {lookAheadSequences, processed: processedLookAhead } = await lookAhead(
+  const { lookAheadSequences, processed: processedLookAhead } = await lookAhead(
     lookAheadSequence,
     filter,
     opts.wormholeRpcs,
@@ -273,7 +273,7 @@ async function lookAhead(
 
     return { lookAheadSequences, processed };
   }
-  
+
   let vaasNotFound = 0;
 
   for (let seq = lookAheadSequence; true; seq++) {
@@ -302,13 +302,15 @@ async function lookAhead(
     }
 
     if (!vaa && vaasNotFound < maxLookAhead) {
-      logger?.debug(`Look Ahead VAA not found. Sequence: ${seq.toString()}`)
+      logger?.debug(`Look Ahead VAA not found. Sequence: ${seq.toString()}`);
       vaasNotFound++;
       continue;
     }
 
     if (!vaa && vaasNotFound >= maxLookAhead) {
-      logger?.debug(`Look Ahead VAA reached max look ahead. Sequence: ${seq.toString()}`)
+      logger?.debug(
+        `Look Ahead VAA reached max look ahead. Sequence: ${seq.toString()}`,
+      );
       break;
     }
 

--- a/relayer/middleware/missedVaasV3/check.ts
+++ b/relayer/middleware/missedVaasV3/check.ts
@@ -168,9 +168,10 @@ export async function checkForMissedVaas(
     filter,
     opts.wormholeRpcs,
     processVaa,
-    processed,
     logger,
   );
+
+  processed.push(...lookAheadSequences);
 
   return {
     processed,
@@ -253,7 +254,6 @@ async function lookAhead(
   filter: FilterIdentifier,
   wormholeRpcs: string[],
   processVaa: ProcessVaaFn,
-  processed: string[],
   logger?: Logger,
 ) {
   logger?.info(

--- a/relayer/middleware/missedVaasV3/check.ts
+++ b/relayer/middleware/missedVaasV3/check.ts
@@ -329,7 +329,7 @@ async function lookAhead(
     }
   }
 
-  return { lookAheadSequences,processed };
+  return { lookAheadSequences, processed };
 }
 
 function scanForSequenceLeaps(seenSequences: bigint[]) {

--- a/relayer/middleware/missedVaasV3/check.ts
+++ b/relayer/middleware/missedVaasV3/check.ts
@@ -299,7 +299,7 @@ async function lookAhead(
 
     // Stop looking ahead after failures >= MAX_LOOK_AHEAD
     if (!vaa && lookAheadFailures >= MAX_LOOK_AHEAD) {
-      return lookAheadSequences;
+      break;
     }
 
     if (!vaa) {

--- a/relayer/middleware/missedVaasV3/check.ts
+++ b/relayer/middleware/missedVaasV3/check.ts
@@ -268,7 +268,7 @@ async function lookAhead(
     return lookAheadSequences;
   }
 
-  let vaaNotFound: 0; // Failures counter
+  let vaaNotFound = 0; // Failures counter
   const MAX_LOOK_AHEAD = 10; // TODO: make this configurable
   const LOOK_AHEAD_RETRIES = 3 * wormholeRpcs.length; // Retry 3 times per wormhole rpc. // TODO: should 3 be configurable?
 

--- a/relayer/middleware/missedVaasV3/check.ts
+++ b/relayer/middleware/missedVaasV3/check.ts
@@ -268,7 +268,7 @@ async function lookAhead(
     return lookAheadSequences;
   }
 
-  let lookAheadFailures: 0; // Failures counter
+  let vaaNotFound: 0; // Failures counter
   const MAX_LOOK_AHEAD = 10; // TODO: make this configurable
   const LOOK_AHEAD_RETRIES = 3 * wormholeRpcs.length; // Retry 3 times per wormhole rpc. // TODO: should 3 be configurable?
 
@@ -283,7 +283,7 @@ async function lookAhead(
       vaa = await tryFetchVaa(vaaKey, wormholeRpcs, LOOK_AHEAD_RETRIES);
       // reset failure counter if we successfully fetched a vaa
       if (vaa) {
-        lookAheadFailures = 0;
+        vaaNotFound = 0;
       }
     } catch (error) {
       let message = "unknown";
@@ -298,12 +298,12 @@ async function lookAhead(
     }
 
     // Stop looking ahead after failures >= MAX_LOOK_AHEAD
-    if (!vaa && lookAheadFailures >= MAX_LOOK_AHEAD) {
+    if (!vaa && vaaNotFound >= MAX_LOOK_AHEAD) {
       break;
     }
 
     if (!vaa) {
-      lookAheadFailures++;
+      vaaNotFound++;
       continue;
     }
 

--- a/relayer/middleware/missedVaasV3/helpers.ts
+++ b/relayer/middleware/missedVaasV3/helpers.ts
@@ -162,7 +162,7 @@ export async function tryFetchVaa(
       vaaKey.sequence,
       { transport: FailFastGrpcTransportFactory() },
       100,
-      retries,
+      retries * wormholeRpcs.length,
     );
   } catch (error: any) {
     error.stack = new Error().stack;

--- a/relayer/middleware/missedVaasV3/worker.ts
+++ b/relayer/middleware/missedVaasV3/worker.ts
@@ -36,6 +36,7 @@ export interface MissedVaaOpts extends RedisConnectionOpts {
   checkInterval?: number;
   // Times a VAA will be tried to be fetched when it's found missing
   fetchVaaRetries?: number;
+  maxLookAhead?: number;
   // Max concurrency used for fetching VAAs from wormscan.
   vaasFetchConcurrency?: number;
   /**
@@ -73,6 +74,10 @@ export async function spawnMissedVaaWorker(
   opts.wormholeRpcs = opts.wormholeRpcs ?? defaultWormholeRpcs[app.env];
   if (!metrics) {
     metrics = opts.registry ? initMetrics(opts.registry) : {};
+  }
+
+  if (!opts.maxLookAhead && opts.maxLookAhead !== 0) {
+    opts.maxLookAhead = 10;
   }
 
   const redisPool = createRedisPool(opts);

--- a/test/middleware/missedVaasV3/check.test.ts
+++ b/test/middleware/missedVaasV3/check.test.ts
@@ -426,13 +426,15 @@ describe("MissedVaaV3.check", () => {
 
       getAllProcessedSeqsInOrderMock.mockResolvedValue([1n]);
 
-      await expect(checkForMissedVaas(
-        filter,
-        redis as unknown as Redis,
-        processVaaMock,
-        opts,
-        prefix,
-      )).rejects.toThrow("foo");
+      await expect(
+        checkForMissedVaas(
+          filter,
+          redis as unknown as Redis,
+          processVaaMock,
+          opts,
+          prefix,
+        ),
+      ).rejects.toThrow("foo");
     });
   });
 });


### PR DESCRIPTION
Currently, the behavior is that when it looks ahead it stops after the first failure assuming that it is up-to-date with VAAs published. The problem with this approach is that sometimes the Guarding misses some VAAs, i.e: sequences: [210 - 211 - 212 - 213 (not available in the guardian) - 214...]. In this example, the look-ahead function will continue until 213, it'll fail to fetch it, so it will stop there but we have more VAAs that could be retrieved.

This new approach uses a MAX_LOOK_AHEAD constant so it will continue fetching VAAs until the failures count reaches the MAX_LOOK_AHEAD value set previously, only then it will consider there are no more VAAs available to retrieve.