### PR TITLE
Deps: Bump certusone sdk dependency to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bull-board/api": "^5.8.1",
         "@bull-board/koa": "^5.8.1",
-        "@certusone/wormhole-sdk": "^0.10.5",
+        "@certusone/wormhole-sdk": "^0.10.11",
         "@certusone/wormhole-spydk": "^0.0.1",
         "@datastructures-js/queue": "^4.2.3",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
@@ -625,11 +625,11 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.5.tgz",
-      "integrity": "sha512-wKONuigkakoFx9HplBt2Jh5KPxc7xgtDJVrIb2/SqYWbFrdpiZrMC4H6kTZq2U4+lWtqaCa1aJ1q+3GOTNx2CQ==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.11.tgz",
+      "integrity": "sha512-WG2gmVqc5t5T6WeSkh6aDPMToN0whTJ1WQv9Kke3/bk4ssR6Gn6gv2OXHL0ZzYcUS8hft5EQBTNr1HGNQT2gMQ==",
       "dependencies": {
-        "@certusone/wormhole-sdk-proto-web": "0.0.6",
+        "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@coral-xyz/borsh": "0.2.6",
         "@mysten/sui.js": "0.32.2",
@@ -666,8 +666,9 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.7.tgz",
+      "integrity": "sha512-GCe1/bcqMS0Mt+hsWp4SE4NLL59pWmK0lhQXO0oqAKl0G9AuuTdudySMDF/sLc7z5H2w34bSuSrIEKvPuuSC+w==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",
@@ -12015,11 +12016,11 @@
       }
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.5.tgz",
-      "integrity": "sha512-wKONuigkakoFx9HplBt2Jh5KPxc7xgtDJVrIb2/SqYWbFrdpiZrMC4H6kTZq2U4+lWtqaCa1aJ1q+3GOTNx2CQ==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.11.tgz",
+      "integrity": "sha512-WG2gmVqc5t5T6WeSkh6aDPMToN0whTJ1WQv9Kke3/bk4ssR6Gn6gv2OXHL0ZzYcUS8hft5EQBTNr1HGNQT2gMQ==",
       "requires": {
-        "@certusone/wormhole-sdk-proto-web": "0.0.6",
+        "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@coral-xyz/borsh": "0.2.6",
         "@injectivelabs/networks": "1.10.12",
@@ -12054,7 +12055,9 @@
       }
     },
     "@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.6",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.7.tgz",
+      "integrity": "sha512-GCe1/bcqMS0Mt+hsWp4SE4NLL59pWmK0lhQXO0oqAKl0G9AuuTdudySMDF/sLc7z5H2w34bSuSrIEKvPuuSC+w==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@bull-board/api": "^5.8.1",
     "@bull-board/koa": "^5.8.1",
-    "@certusone/wormhole-sdk": "^0.10.5",
+    "@certusone/wormhole-sdk": "^0.10.11",
     "@certusone/wormhole-spydk": "^0.0.1",
     "@datastructures-js/queue": "^4.2.3",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",


### PR DESCRIPTION
Latest `wormhole-sdk` is 0.10.11, this will also need to be published to NPM (latest version for this package npm is still on 0.9.24)